### PR TITLE
[WIP] Proposal on state store change for new state format

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -314,6 +314,12 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
         key: UnsafeRow, values: Array[UnsafeRow], colFamilyName: String): Unit = {
       throw StateStoreErrors.unsupportedOperationException("mergeList", providerName)
     }
+
+    override def initiateEventTimeAwareStateOperations(
+        columnFamilyName: String): EventTimeAwareStateOperations = {
+      throw StateStoreErrors.unsupportedOperationException(
+        "initiateEventTimeAwareStateOperations", providerName)
+    }
   }
 
   def getMetricsForProvider(): Map[String, Long] = synchronized {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateEncoder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateEncoder.scala
@@ -330,10 +330,37 @@ trait DataEncoder {
    */
   def encodePrefixKeyForRangeScan(row: UnsafeRow): Array[Byte]
 
-  // FIXME: doc!
+  /**
+   * Encodes key and event time, ensuring prefix scan with key and also proper sort order with
+   * event time within the same key in RocksDB.
+   *
+   * This method handles the encoding as follows:
+   * - Encodes the key columns normally and put them first
+   * - Appends the event time Long value in big-endian order as the last 8 bytes
+   *
+   * @param row An UnsafeRow denoting a key
+   * @param eventTime Long value representing the event time
+   * @return Serialized bytes that will maintain prefix scan with key and sort order with
+   *         event time
+   * @throws UnsupportedOperationException if called on an encoder that doesn't support event time
+   *                                       as postfix.
+   */
   def encodeKeyForEventTimeAsPostfix(row: UnsafeRow, eventTime: Long): Array[Byte]
 
-  // FIXME: doc!
+  /**
+   * Encodes key and event time, ensuring proper sort order with event time across keys in
+   * RocksDB.
+   *
+   * This method handles the encoding done as follows:
+   * - Encodes the event time Long value in big-endian order and put them first
+   * - Appends the encoded key columns as the remaining bytes
+   *
+   * @param row An UnsafeRow denoting a key
+   * @param eventTime Long value representing the event time
+   * @return Serialized bytes that will maintain sort order with event time across keys
+   * @throws UnsupportedOperationException if called on an encoder that doesn't support event time
+   *                                       as prefix.
+   */
   def encodeKeyForEventTimeAsPrefix(row: UnsafeRow, eventTime: Long): Array[Byte]
 
   /**
@@ -382,10 +409,34 @@ trait DataEncoder {
    */
   def decodePrefixKeyForRangeScan(bytes: Array[Byte]): UnsafeRow
 
-  // FIXME: doc!
+  /**
+   * Decodes key bytes containing key and event time appended as postfix back into an UnsafeRow
+   * and event time.
+   *
+   * This method reverses the encoding done by encodeKeyForEventTimeAsPostfix:
+   * - Read the bytes excluding the last 8 bytes as the key UnsafeRow
+   * - Read the last 8 bytes as the event time Long value
+   *
+   * @param bytes Serialized byte array containing the encoded key and event time
+   * @return UnsafeRow containing the decoded key columns and the event time Long value
+   * @throws UnsupportedOperationException if called on an encoder that doesn't support event time
+   *                                       as postfix.
+   */
   def decodeKeyForEventTimeAsPostfix(bytes: Array[Byte]): (UnsafeRow, Long)
 
-  // FIXME: doc!
+  /**
+   * Decodes key bytes containing event time appended as prefix and key back into an UnsafeRow
+   * and event time.
+   *
+   * This method reverses the encoding done by encodeKeyForEventTimeAsPrefix:
+   * - Read the 8 bytes as the event time Long value
+   * - Read the remaining bytes as the key UnsafeRow
+   *
+   * @param bytes Serialized byte array containing the encoded key and event time
+   * @return UnsafeRow containing the decoded key columns and the event time Long value
+   * @throws UnsupportedOperationException if called on an encoder that doesn't support event time
+   *                                       as prefix.
+   */
   def decodeKeyForEventTimeAsPrefix(bytes: Array[Byte]): (UnsafeRow, Long)
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateEncoder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateEncoder.scala
@@ -987,10 +987,8 @@ class AvroStateEncoder(
           }
         }
         StructType(remainingSchema)
-      case EventTimeAsPostfixStateEncoderSpec(schema) =>
-        schema
-      case EventTimeAsPrefixStateEncoderSpec(schema) =>
-        schema
+      case _ =>
+        throw unsupportedOperationForKeyStateEncoder("createAvroEnc")
     }
 
     // Handle suffix key schema for prefix scan case
@@ -1147,18 +1145,6 @@ class AvroStateEncoder(
           StateSchemaIdRow(currentKeySchemaId, avroRow))
       case PrefixKeyScanStateEncoderSpec(_, _) =>
         encodeUnsafeRowToAvro(row, avroEncoder.keySerializer, prefixKeyAvroType, out)
-      case EventTimeAsPostfixStateEncoderSpec(_) =>
-        val avroRow =
-          encodeUnsafeRowToAvro(row, avroEncoder.keySerializer, keyAvroType, out)
-        // prepend stateSchemaId to the Avro-encoded key portion for EventTimeAsPostfix keys
-        encodeWithStateSchemaId(
-          StateSchemaIdRow(currentKeySchemaId, avroRow))
-      case EventTimeAsPrefixStateEncoderSpec(_) =>
-        val avroRow =
-          encodeUnsafeRowToAvro(row, avroEncoder.keySerializer, keyAvroType, out)
-        // prepend stateSchemaId to the Avro-encoded key portion for EventTimeAsPrefix keys
-        encodeWithStateSchemaId(
-          StateSchemaIdRow(currentKeySchemaId, avroRow))
       case _ => throw unsupportedOperationForKeyStateEncoder("encodeKey")
     }
     prependVersionByte(keyBytes)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateEncoder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateEncoder.scala
@@ -1147,6 +1147,18 @@ class AvroStateEncoder(
           StateSchemaIdRow(currentKeySchemaId, avroRow))
       case PrefixKeyScanStateEncoderSpec(_, _) =>
         encodeUnsafeRowToAvro(row, avroEncoder.keySerializer, prefixKeyAvroType, out)
+      case EventTimeAsPostfixStateEncoderSpec(_) =>
+        val avroRow =
+          encodeUnsafeRowToAvro(row, avroEncoder.keySerializer, keyAvroType, out)
+        // prepend stateSchemaId to the Avro-encoded key portion for EventTimeAsPostfix keys
+        encodeWithStateSchemaId(
+          StateSchemaIdRow(currentKeySchemaId, avroRow))
+      case EventTimeAsPrefixStateEncoderSpec(_) =>
+        val avroRow =
+          encodeUnsafeRowToAvro(row, avroEncoder.keySerializer, keyAvroType, out)
+        // prepend stateSchemaId to the Avro-encoded key portion for EventTimeAsPrefix keys
+        encodeWithStateSchemaId(
+          StateSchemaIdRow(currentKeySchemaId, avroRow))
       case _ => throw unsupportedOperationForKeyStateEncoder("encodeKey")
     }
     prependVersionByte(keyBytes)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -546,7 +546,6 @@ private[sql] class RocksDBStateStoreProvider
         new StateStoreIterator(iter, rocksDbIter.closeIfNeeded)
       }
 
-      // FIXME: probably not a good name since it's only to iterate keys sorted with event time
       override def iterator(): StateStoreIterator[UnsafeRowPairWithEventTime] = {
         validateAndTransitionState(UPDATE)
         // Note this verify function only verify on the colFamilyName being valid,
@@ -557,8 +556,6 @@ private[sql] class RocksDBStateStoreProvider
 
         require(keyEncoder.supportEventTime,
           "iterator requires encoder supporting event time!")
-        // FIXME: should we have a marker to denote that keyEncoder supports range scan
-        //  with event time?
 
         val rowPair = new UnsafeRowPairWithEventTime()
         val rocksDbIter = rocksDB.iterator(columnFamilyName)
@@ -592,8 +589,6 @@ private[sql] class RocksDBStateStoreProvider
         require(useColumnFamilies, "iteratorWithMultiValues requires using " +
           "column families!")
 
-        // FIXME: should we have a marker to denote that keyEncoder supports range scan
-        //  with event time?
         val rowPair = new UnsafeRowPairWithEventTime()
         val rocksDbIter = rocksDB.iterator(columnFamilyName)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -466,6 +466,7 @@ private[sql] class RocksDBStateStoreProvider
       override def get(key: UnsafeRow, eventTime: Long): UnsafeRow = {
         validateAndTransitionState(UPDATE)
         verifyColFamilyOperations("get", columnFamilyName)
+        verify(key != null, "Key cannot be null")
 
         val value = valueEncoder.decodeValue(
           rocksDB.get(keyEncoder.encodeKeyWithEventTime(key, eventTime), columnFamilyName))
@@ -507,7 +508,7 @@ private[sql] class RocksDBStateStoreProvider
           "prefixScan requires encoder supporting prefix scan!")
 
         val rowPair = new UnsafeRowPairWithEventTime()
-        val prefix = keyEncoder.encodeKey(prefixKey)
+        val prefix = keyEncoder.encodePrefixKey(prefixKey)
 
         val rocksDbIter = rocksDB.prefixScan(prefix, columnFamilyName)
         val iter = rocksDbIter.map { kv =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -528,8 +528,12 @@ private[sql] class RocksDBStateStoreProvider
         validateAndTransitionState(UPDATE)
         verifyColFamilyOperations("prefixScanWithMultiValues", columnFamilyName)
 
-        require(keyEncoder.supportPrefixKeyScan,
+        verify(keyEncoder.supportPrefixKeyScan,
           "prefixScanWithMultiValues requires encoder supporting prefix scan!")
+        verify(
+          valueEncoder.supportsMultipleValuesPerKey,
+          "Multi-value iterator operation requires an encoder" +
+            " which supports multiple values for a single key")
 
         val prefix = keyEncoder.encodePrefixKey(prefixKey)
 
@@ -553,10 +557,7 @@ private[sql] class RocksDBStateStoreProvider
         // we are actually doing prefix when useColumnFamilies,
         // but pass "iterator" to throw correct error message
         verifyColFamilyOperations("iterator", columnFamilyName)
-        require(useColumnFamilies, "iterator requires using column families!")
-
-        require(keyEncoder.supportEventTime,
-          "iterator requires encoder supporting event time!")
+        verify(useColumnFamilies, "iterator requires using column families!")
 
         val rowPair = new UnsafeRowPairWithEventTime()
         val rocksDbIter = rocksDB.iterator(columnFamilyName)
@@ -587,8 +588,10 @@ private[sql] class RocksDBStateStoreProvider
         // but pass "iteratorWithMultiValues" to throw correct error message
         verifyColFamilyOperations("iteratorWithMultiValues", columnFamilyName)
 
-        require(useColumnFamilies, "iteratorWithMultiValues requires using " +
-          "column families!")
+        verify(
+          valueEncoder.supportsMultipleValuesPerKey,
+          "Multi-value iterator operation requires an encoder" +
+            " which supports multiple values for a single key")
 
         val rowPair = new UnsafeRowPairWithEventTime()
         val rocksDbIter = rocksDB.iterator(columnFamilyName)
@@ -619,7 +622,7 @@ private[sql] class RocksDBStateStoreProvider
         validateAndTransitionState(UPDATE)
         verify(state == UPDATING, "Cannot put after already committed or aborted")
         verify(key != null, "Key cannot be null")
-        require(value != null, "Cannot put a null value")
+        verify(value != null, "Cannot put a null value")
         verifyColFamilyOperations("put", columnFamilyName)
 
         rocksDB.put(
@@ -635,7 +638,7 @@ private[sql] class RocksDBStateStoreProvider
         validateAndTransitionState(UPDATE)
         verify(state == UPDATING, "Cannot put after already committed or aborted")
         verify(key != null, "Key cannot be null")
-        require(values != null, "Cannot put a null value")
+        verify(values != null, "Cannot put a null value")
         verifyColFamilyOperations("putList", columnFamilyName)
 
         verify(
@@ -667,7 +670,7 @@ private[sql] class RocksDBStateStoreProvider
         validateAndTransitionState(UPDATE)
         verify(state == UPDATING, "Cannot merge after already committed or aborted")
         verify(key != null, "Key cannot be null")
-        require(value != null, "Cannot put a null value")
+        verify(value != null, "Cannot put a null value")
         verifyColFamilyOperations("merge", columnFamilyName)
 
         verify(valueEncoder.supportsMultipleValuesPerKey, "Merge operation requires an encoder" +

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -318,34 +318,106 @@ trait StateStore extends ReadStateStore {
    */
   def hasCommitted: Boolean
 
+  /** Initiate event-time aware state operations for the given column family. */
   def initiateEventTimeAwareStateOperations(
       columnFamilyName: String): EventTimeAwareStateOperations
 }
 
+/**
+ * The interface for event-time aware state operations, which are based on (key, eventTime, value)
+ * data structure instead of (key, value).
+ */
 trait EventTimeAwareStateOperations {
+  /** The target column family the operations with this instance is applied to. */
   def columnFamilyName: String
 
+  /** Get the current value of a non-null key with the event time. */
   def get(key: UnsafeRow, eventTime: Long): UnsafeRow
 
+  /**
+   * Provides an iterator containing all values of a non-null key with event time.
+   * If key does not exist, an empty iterator is returned. Implementations should make sure
+   * to return an empty iterator if the key does not exist.
+   *
+   * It is expected to throw exception if Spark calls this method without setting
+   * multipleValuesPerKey as true for the column family.
+   */
   def valuesIterator(key: UnsafeRow, eventTime: Long): Iterator[UnsafeRow]
 
+  /**
+   * Return an iterator containing all the (key, event time, value) pairs which are matched with
+   * the given prefix key. In [[EventTimeAwareStateOperations]], prefix key is a key, while the
+   * remaining key is event time.
+   *
+   * It is expected to throw exception if Spark calls this method without proper key encoding spec.
+   */
   def prefixScan(prefixKey: UnsafeRow): StateStoreIterator[UnsafeRowPairWithEventTime]
 
+  /**
+   * Return an iterator containing all the (key, event time, value) pairs which are matched with
+   * the given prefix key. In [[EventTimeAwareStateOperations]], prefix key is a key, while the
+   * remaining key is event time. This method should be used for multiple values per key.
+   *
+   * It is expected to throw exception if Spark calls this method without proper key encoding spec.
+   * It is also expected to throw exception if Spark calls this method without setting
+   * multipleValuesPerKey as true for the column family.
+   */
   def prefixScanWithMultiValues(
       prefixKey: UnsafeRow): StateStoreIterator[UnsafeRowPairWithEventTime]
 
+  /**
+   * Return an iterator containing all the (key, event time, value) pairs in the StateStore.
+   * The column family with the key encoding spec having event time as prefix produces the
+   * data in the order of eventTime.
+   */
   def iterator(): StateStoreIterator[UnsafeRowPairWithEventTime]
 
+  /**
+   * Return an iterator containing all the (key, event time, value) pairs in the StateStore.
+   * The column family with the key encoding spec having event time as prefix produces the
+   * data in the order of eventTime. This method should be used for multiple values per key.
+   *
+   * It is expected to throw exception if Spark calls this method without setting
+   * multipleValuesPerKey as true for the column family.
+   */
   def iteratorWithMultiValues(): StateStoreIterator[UnsafeRowPairWithEventTime]
 
+  /**
+   * Put a new non-null value for a non-null key with event time. Implementations must be aware
+   * that the UnsafeRows in the params can be reused, and must make copies of the data as needed
+   * for persistence.
+   */
   def put(key: UnsafeRow, eventTime: Long, value: UnsafeRow): Unit
 
+  /**
+   * Put a new list of non-null values for a non-null key with event time. Implementations must
+   * be aware that the UnsafeRows in the params can be reused, and must make copies of the data
+   * as needed for persistence.
+   *
+   * It is expected to throw exception if Spark calls this method without setting
+   * multipleValuesPerKey as true for the column family.
+   */
   def putList(key: UnsafeRow, eventTime: Long, values: Array[UnsafeRow]): Unit
 
+  /** Remove a single non-null key with event time. */
   def remove(key: UnsafeRow, eventTime: Long): Unit
 
+  /**
+   * Merges the provided value with existing values of a non-null key and event time. If a existing
+   * value does not exist, this operation behaves as [[StateStore.put()]].
+   *
+   * It is expected to throw exception if Spark calls this method without setting
+   * multipleValuesPerKey as true for the column family.
+   */
   def merge(key: UnsafeRow, eventTime: Long, value: UnsafeRow): Unit
 
+  /**
+   * Merges the provided list of values with existing values of a non-null key and event time.
+   * If a existing value does not exist, this operation behaves as [[StateStore.putList()]].
+   *
+   * It is expected to throw exception if Spark calls this method without setting
+   * multipleValuesPerKey as true for the column family.
+   */
   def mergeList(key: UnsafeRow, eventTime: Long, values: Array[UnsafeRow]): Unit
 }
 
@@ -635,6 +707,10 @@ case class RangeKeyScanStateEncoderSpec(
   }
 }
 
+/**
+ * Encodes row with event time as prefix of the key, so that they can be scanned based on
+ * event time ordering.
+ */
 case class EventTimeAsPrefixStateEncoderSpec(keySchema: StructType) extends KeyStateEncoderSpec {
   override def toEncoder(
       dataEncoder: RocksDBDataEncoder,
@@ -647,6 +723,11 @@ case class EventTimeAsPrefixStateEncoderSpec(keySchema: StructType) extends KeyS
   }
 }
 
+/**
+ * Encodes row with event time as postfix of the key, so that prefix scan with the keys
+ * having the same key but different event times is supported. In addition, event time is stored
+ * in sort order to support event time ordered iteration in the result of prefix scan.
+ */
 case class EventTimeAsPostfixStateEncoderSpec(keySchema: StructType) extends KeyStateEncoderSpec {
   override def toEncoder(
       dataEncoder: RocksDBDataEncoder,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -322,9 +322,6 @@ trait StateStore extends ReadStateStore {
       columnFamilyName: String): EventTimeAwareStateOperations
 }
 
-// FIXME: Should we make this to control the lifecycle of the state store as well, or just limit
-//  to the operations? We may name this a bit differently if we want to make this also control
-//  the lifecycle.
 trait EventTimeAwareStateOperations {
   def columnFamilyName: String
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -317,6 +317,39 @@ trait StateStore extends ReadStateStore {
    * Whether all updates have been committed
    */
   def hasCommitted: Boolean
+
+  def initiateEventTimeAwareStateOperations(
+      columnFamilyName: String): EventTimeAwareStateOperations
+}
+
+// FIXME: Should we make this to control the lifecycle of the state store as well, or just limit
+//  to the operations? We may name this a bit differently if we want to make this also control
+//  the lifecycle.
+trait EventTimeAwareStateOperations {
+  def columnFamilyName: String
+
+  def get(key: UnsafeRow, eventTime: Long): UnsafeRow
+
+  def valuesIterator(key: UnsafeRow, eventTime: Long): Iterator[UnsafeRow]
+
+  def prefixScan(prefixKey: UnsafeRow): StateStoreIterator[UnsafeRowPairWithEventTime]
+
+  def prefixScanWithMultiValues(
+      prefixKey: UnsafeRow): StateStoreIterator[UnsafeRowPairWithEventTime]
+
+  def iterator(): StateStoreIterator[UnsafeRowPairWithEventTime]
+
+  def iteratorWithMultiValues(): StateStoreIterator[UnsafeRowPairWithEventTime]
+
+  def put(key: UnsafeRow, eventTime: Long, value: UnsafeRow): Unit
+
+  def putList(key: UnsafeRow, eventTime: Long, values: Array[UnsafeRow]): Unit
+
+  def remove(key: UnsafeRow, eventTime: Long): Unit
+
+  def merge(key: UnsafeRow, eventTime: Long, value: UnsafeRow): Unit
+
+  def mergeList(key: UnsafeRow, eventTime: Long, values: Array[UnsafeRow]): Unit
 }
 
 /** Wraps the instance of StateStore to make the instance read-only. */
@@ -602,6 +635,30 @@ case class RangeKeyScanStateEncoderSpec(
   override def jsonValue: JValue = {
     ("keyStateEncoderType" -> JString("RangeKeyScanStateEncoderSpec")) ~
       ("orderingOrdinals" -> orderingOrdinals.map(JInt(_)))
+  }
+}
+
+case class EventTimeAsPrefixStateEncoderSpec(keySchema: StructType) extends KeyStateEncoderSpec {
+  override def toEncoder(
+      dataEncoder: RocksDBDataEncoder,
+      useColumnFamilies: Boolean): RocksDBKeyStateEncoder = {
+    new EventTimeAsPrefixStateEncoder(dataEncoder, keySchema, useColumnFamilies)
+  }
+
+  override def jsonValue: JValue = {
+    "keyStateEncoderType" -> JString("EventTimeAsPrefixStateEncoderSpec")
+  }
+}
+
+case class EventTimeAsPostfixStateEncoderSpec(keySchema: StructType) extends KeyStateEncoderSpec {
+  override def toEncoder(
+      dataEncoder: RocksDBDataEncoder,
+      useColumnFamilies: Boolean): RocksDBKeyStateEncoder = {
+    new EventTimeAsPostfixStateEncoder(dataEncoder, keySchema, useColumnFamilies)
+  }
+
+  override def jsonValue: JValue = {
+    "keyStateEncoderType" -> JString("EventTimeAsPostfixStateEncoderSpec")
   }
 }
 
@@ -1048,6 +1105,17 @@ class UnsafeRowPair(var key: UnsafeRow = null, var value: UnsafeRow = null) {
   }
 }
 
+class UnsafeRowPairWithEventTime(
+    var key: UnsafeRow = null,
+    var eventTime: Long = -1L,
+    var value: UnsafeRow = null) {
+  def withRows(key: UnsafeRow, eventTime: Long, value: UnsafeRow): UnsafeRowPairWithEventTime = {
+    this.key = key
+    this.eventTime = eventTime
+    this.value = value
+    this
+  }
+}
 
 /**
  * Companion object to [[StateStore]] that provides helper methods to create and retrieve stores

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MemoryStateStore.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MemoryStateStore.scala
@@ -93,6 +93,11 @@ class MemoryStateStore extends StateStore() {
     throw new UnsupportedOperationException("Doesn't support multiple values per key")
   }
 
+  override def initiateEventTimeAwareStateOperations(
+      columnFamilyName: String): EventTimeAwareStateOperations = {
+    throw new UnsupportedOperationException("Doesn't support event time aware operations")
+  }
+
   override def getStateStoreCheckpointInfo(): StateStoreCheckpointInfo = {
     StateStoreCheckpointInfo(id.partitionId, version + 1, None, None)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBEventTimeAwareStateOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBEventTimeAwareStateOperationsSuite.scala
@@ -236,7 +236,7 @@ class RocksDBEventTimeAwareStateOperationsSuite extends SharedSparkSession
             val eventTime = 1000L
 
             // Test null value should throw exception
-            intercept[IllegalArgumentException] {
+            intercept[IllegalStateException] {
               operations.put(key, eventTime, null)
             }
           } finally {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBEventTimeAwareStateOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBEventTimeAwareStateOperationsSuite.scala
@@ -1,0 +1,605 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.streaming.state
+
+import java.util.UUID
+
+import scala.util.Random
+
+import org.apache.hadoop.conf.Configuration
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.should.Matchers
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.execution.streaming.runtime.StreamExecution
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types._
+import org.apache.spark.tags.ExtendedSQLTest
+import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.util.Utils
+
+@ExtendedSQLTest
+class RocksDBEventTimeAwareStateOperationsSuite extends SharedSparkSession
+  with BeforeAndAfterEach with Matchers {
+
+  // Test schemas
+  private val keySchema = StructType(Seq(
+    StructField("key", StringType, nullable = true),
+    StructField("partitionId", IntegerType, nullable = true)
+  ))
+  private val valueSchema = StructType(Seq(StructField("value", IntegerType, nullable = true)))
+
+  // Column family names for testing
+  private val testColFamily = "test_cf"
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    StateStore.stop()
+    require(!StateStore.isMaintenanceRunning)
+    spark.streams.stateStoreCoordinator // initialize the lazy coordinator
+  }
+
+  override def afterEach(): Unit = {
+    StateStore.stop()
+    require(!StateStore.isMaintenanceRunning)
+    super.afterEach()
+  }
+
+  // Helper methods to create test data
+  private def stringToRow(s: String): UnsafeRow = {
+    UnsafeProjection.create(Array[DataType](StringType))
+      .apply(InternalRow(UTF8String.fromString(s)))
+  }
+
+  private def intToRow(i: Int): UnsafeRow = {
+    UnsafeProjection.create(Array[DataType](IntegerType)).apply(InternalRow(i))
+  }
+
+  private def keyToRow(key: String, partitionId: Int): UnsafeRow = {
+    UnsafeProjection.create(keySchema)
+      .apply(InternalRow(UTF8String.fromString(key), partitionId))
+  }
+
+  private def valueToRow(value: Int): UnsafeRow = {
+    UnsafeProjection.create(valueSchema).apply(InternalRow(value))
+  }
+
+  // Helper to create a new store provider with event time encoder
+  private def newStoreProviderWithEventTime(
+      encoderType: String = "prefix", // "prefix" or "postfix"
+      useColumnFamilies: Boolean = true,
+      useMultipleValuesPerKey: Boolean = false,
+      dataEncoding: String = "unsaferow"): RocksDBStateStoreProvider = {
+
+    val keyStateEncoderSpec = encoderType match {
+      case "prefix" => EventTimeAsPrefixStateEncoderSpec(keySchema)
+      case "postfix" => EventTimeAsPostfixStateEncoderSpec(keySchema)
+      case _ => throw new IllegalArgumentException(s"Unknown encoder type: $encoderType")
+    }
+
+    // Create a copy of SQLConf and set data encoding format on it
+    val sqlConf = SQLConf.get.clone()
+    sqlConf.setConfString(
+      "spark.sql.streaming.stateStore.encodingFormat",
+      dataEncoding)
+
+    val provider = new RocksDBStateStoreProvider()
+    val stateStoreId = StateStoreId(newDir(), Random.nextInt(), 0)
+    val conf = new Configuration
+    conf.set(StreamExecution.RUN_ID_KEY, UUID.randomUUID().toString)
+
+    val storeConf = new StateStoreConf(sqlConf)
+    provider.init(
+      stateStoreId,
+      keySchema,
+      valueSchema,
+      keyStateEncoderSpec,
+      useColumnFamilies,
+      storeConf,
+      conf,
+      useMultipleValuesPerKey)
+
+    provider
+  }
+
+  // Helper to get event time aware state operations
+  // Returns both the store and operations so caller can manage store lifecycle
+  private def getEventTimeAwareOps(
+      provider: RocksDBStateStoreProvider,
+      version: Long = 0,
+      columnFamily: String = testColFamily,
+      encoderType: String = "prefix",
+      useMultipleValuesPerKey: Boolean = false): (StateStore, EventTimeAwareStateOperations) = {
+
+    val keyStateEncoderSpec = encoderType match {
+      case "prefix" => EventTimeAsPrefixStateEncoderSpec(keySchema)
+      case "postfix" => EventTimeAsPostfixStateEncoderSpec(keySchema)
+      case _ => throw new IllegalArgumentException(s"Unknown encoder type: $encoderType")
+    }
+
+    val store = provider.getStore(version).asInstanceOf[provider.RocksDBStateStore]
+
+    // Create column family for testing
+    store.createColFamilyIfAbsent(
+      columnFamily,
+      keySchema,
+      valueSchema,
+      keyStateEncoderSpec,
+      useMultipleValuesPerKey = useMultipleValuesPerKey)
+
+    val operations = store.initiateEventTimeAwareStateOperations(columnFamily)
+    (store, operations)
+  }
+
+  private def newDir(): String = Utils.createTempDir().getCanonicalPath
+
+  Seq("unsaferow", "avro").foreach { encoding =>
+    Seq("prefix", "postfix").foreach { encoderType =>
+      test(s"Event time as $encoderType: basic put and get operations (encoding = $encoding)") {
+        tryWithProviderResource(
+          newStoreProviderWithEventTime(
+            encoderType = "prefix", dataEncoding = encoding)) { provider =>
+          val (store, operations) = getEventTimeAwareOps(provider, encoderType = "prefix")
+          try {
+            val key1 = keyToRow("key1", 1)
+            val value1 = valueToRow(100)
+            val eventTime1 = 1000L
+
+            // Test put and get
+            operations.put(key1, eventTime1, value1)
+            val retrievedValue = operations.get(key1, eventTime1)
+
+            assert(retrievedValue != null)
+            assert(retrievedValue.getInt(0) === 100)
+
+            // Test get with different event time should return null
+            val nonExistentValue = operations.get(key1, 2000L)
+            assert(nonExistentValue === null)
+
+            // Test with different key should return null
+            val key2 = keyToRow("key2", 1)
+            val nonExistentValue2 = operations.get(key2, eventTime1)
+            assert(nonExistentValue2 === null)
+          } finally {
+            store.abort()
+          }
+        }
+      }
+
+      test(s"Event time as $encoderType: remove operations (encoding = $encoding)") {
+        tryWithProviderResource(
+          newStoreProviderWithEventTime(
+            encoderType = encoderType, dataEncoding = encoding)) { provider =>
+          val (store, operations) = getEventTimeAwareOps(provider)
+          try {
+            val key1 = keyToRow("key1", 1)
+            val value1 = valueToRow(100)
+            val eventTime1 = 1000L
+
+            // Put and verify
+            operations.put(key1, eventTime1, value1)
+            assert(operations.get(key1, eventTime1) != null)
+
+            // Remove and verify
+            operations.remove(key1, eventTime1)
+            assert(operations.get(key1, eventTime1) === null)
+
+            // Removing non-existent key should not throw error
+            operations.remove(keyToRow("nonexistent", 1), 2000L)
+          } finally {
+            store.abort()
+          }
+        }
+      }
+
+      test(s"Event time as $encoderType: multiple values per key (encoding = $encoding)") {
+        tryWithProviderResource(
+          newStoreProviderWithEventTime(
+            encoderType = encoderType,
+            useMultipleValuesPerKey = true,
+            dataEncoding = encoding)
+        ) { provider =>
+          val (store, operations) =
+            getEventTimeAwareOps(provider, useMultipleValuesPerKey = true)
+          try {
+            val key1 = keyToRow("key1", 1)
+            val values = Array(valueToRow(100), valueToRow(200), valueToRow(300))
+            val eventTime1 = 1000L
+
+            // Test putList
+            operations.putList(key1, eventTime1, values)
+
+            // Test valuesIterator
+            val retrievedValues =
+              operations.valuesIterator(key1, eventTime1).toList
+            assert(retrievedValues.length === 3)
+            assert(
+              retrievedValues.map(_.getInt(0)).sorted === Array(
+                100,
+                200,
+                300
+              ).sorted
+            )
+
+            // Test with different event time should return empty iterator
+            val emptyIterator = operations.valuesIterator(key1, 2000L)
+            assert(!emptyIterator.hasNext)
+          } finally {
+            store.abort()
+          }
+        }
+      }
+
+      test(s"Event time as $encoderType: merge operations (encoding = $encoding)") {
+        tryWithProviderResource(
+          newStoreProviderWithEventTime(
+            encoderType = encoderType,
+            useMultipleValuesPerKey = true,
+            dataEncoding = encoding)
+        ) { provider =>
+          val (store, operations) =
+            getEventTimeAwareOps(provider, useMultipleValuesPerKey = true)
+          try {
+            val key1 = keyToRow("key1", 1)
+            val value1 = valueToRow(100)
+            val value2 = valueToRow(200)
+            val eventTime1 = 1000L
+
+            // Test merge single values
+            operations.merge(key1, eventTime1, value1)
+            operations.merge(key1, eventTime1, value2)
+
+            val retrievedValues =
+              operations.valuesIterator(key1, eventTime1).toList
+            assert(retrievedValues.length === 2)
+            assert(retrievedValues.map(_.getInt(0)).toSet === Set(100, 200))
+
+            // Test mergeList
+            val additionalValues = Array(valueToRow(300), valueToRow(400))
+            operations.mergeList(key1, eventTime1, additionalValues)
+
+            val allValues = operations.valuesIterator(key1, eventTime1).toList
+            assert(allValues.length === 4)
+            assert(allValues.map(_.getInt(0)).toSet === Set(100, 200, 300, 400))
+          } finally {
+            store.abort()
+          }
+        }
+      }
+
+      test(s"Event time as $encoderType: null key validation (encoding = $encoding)") {
+        tryWithProviderResource(
+          newStoreProviderWithEventTime(
+            encoderType = encoderType, dataEncoding = encoding)) { provider =>
+          val (store, operations) = getEventTimeAwareOps(provider)
+          try {
+            val value = valueToRow(100)
+            val eventTime = 1000L
+
+            // Test null key should throw exception
+            intercept[IllegalStateException] {
+              operations.put(null, eventTime, value)
+            }
+
+            intercept[IllegalStateException] {
+              operations.get(null, eventTime)
+            }
+
+            intercept[IllegalStateException] {
+              operations.remove(null, eventTime)
+            }
+          } finally {
+            store.abort()
+          }
+        }
+      }
+
+      test(s"Event time as $encoderType: null value validation (encoding = $encoding)") {
+        tryWithProviderResource(
+          newStoreProviderWithEventTime(
+            encoderType = encoderType, dataEncoding = encoding)) { provider =>
+          val (store, operations) = getEventTimeAwareOps(provider)
+          try {
+            val key = keyToRow("key1", 1)
+            val eventTime = 1000L
+
+            // Test null value should throw exception
+            intercept[IllegalArgumentException] {
+              operations.put(key, eventTime, null)
+            }
+          } finally {
+            store.abort()
+          }
+        }
+      }
+    }
+  }
+
+  Seq("unsaferow", "avro").foreach { encoding =>
+    test(s"Event time as prefix: iterator operations (encoding = $encoding)") {
+      tryWithProviderResource(
+        newStoreProviderWithEventTime(
+          encoderType = "prefix", dataEncoding = encoding)) { provider =>
+        val operations = getEventTimeAwareOps(provider)
+
+        val entries = Map(
+          (keyToRow("key1", 1), 2000L) -> valueToRow(100),
+          (keyToRow("key2", 1), 1500L) -> valueToRow(200),
+          (keyToRow("key1", 2), 1000L) -> valueToRow(300)
+        )
+
+        // Put all entries (in non-sorted order)
+        entries.foreach { case ((key, eventTime), value) =>
+          operations.put(key, eventTime, value)
+        }
+
+        // Test iterator - should return all entries ordered by event time
+        val iterator = operations.iterator()
+        val results = iterator.map { pair =>
+          val keyString = pair.key.getString(0)
+          val partitionId = pair.key.getInt(1)
+          val eventTime = pair.eventTime
+          val value = pair.value.getInt(0)
+          (keyString, partitionId, eventTime, value)
+        }.toList
+
+        iterator.close()
+
+        assert(results.length === 3)
+
+        // Verify results are ordered by event time (ascending)
+        val eventTimes = results.map(_._3)
+        assert(
+          eventTimes === Seq(1000L, 1500L, 2000L),
+          "Results should be ordered by event time"
+        )
+
+        // Verify all expected entries are present
+        val retrievedEntries = results.map {
+          case (key, partId, time, value) =>
+            ((key, partId, time), value)
+        }.toMap
+        assert(retrievedEntries((("key1", 2, 1000L))) === 300)
+        assert(retrievedEntries((("key2", 1, 1500L))) === 200)
+        assert(retrievedEntries((("key1", 1, 2000L))) === 100)
+      }
+    }
+
+    test(s"Event time as prefix: iterator with multiple values (encoding = $encoding)") {
+      tryWithProviderResource(
+        newStoreProviderWithEventTime(
+          encoderType = "prefix",
+          useMultipleValuesPerKey = true,
+          dataEncoding = encoding)
+      ) { provider =>
+        val operations =
+          getEventTimeAwareOps(provider, useMultipleValuesPerKey = true)
+
+        val key1 = keyToRow("key1", 1)
+        val values1 = Array(valueToRow(100), valueToRow(101))
+        val key2 = keyToRow("key2", 1)
+        val values2 = Array(valueToRow(200))
+        val eventTime = 1000L
+
+        operations.putList(key1, eventTime, values1)
+        operations.putList(key2, eventTime, values2)
+
+        // Test iteratorWithMultiValues
+        val iterator = operations.iteratorWithMultiValues()
+        val retrievedValues = iterator.map { pair =>
+          pair.value.getInt(0)
+        }.toList
+
+        iterator.close()
+
+        assert(
+          retrievedValues.length === 3
+        ) // 2 values from key1 + 1 value from key2
+        assert(retrievedValues.toSet === Set(100, 101, 200))
+      }
+    }
+
+    test(
+      s"Event time as postfix: prefix scan operations (encoding = $encoding)"
+    ) {
+      tryWithProviderResource(
+        newStoreProviderWithEventTime(encoderType = "postfix", dataEncoding = encoding)
+      ) { provider =>
+        val operations =
+          getEventTimeAwareOps(provider, encoderType = "postfix")
+
+        // Put entries with the same complete key but different event times
+        // Prefix scan should find all entries with the same key across different event times
+        val key1 = keyToRow("key1", 1)
+        val key2 = keyToRow("key2", 1) // Different key
+
+        // Insert in non-sorted order to verify that prefix scan returns them sorted by time
+        operations.put(key1, 3000L, valueToRow(102))
+        operations.put(key1, 1000L, valueToRow(100))
+        operations.put(key1, 2000L, valueToRow(101))
+
+        // Different key (key2, 1) - should not be returned
+        operations.put(key2, 1500L, valueToRow(200))
+
+        // Test prefixScan - pass the complete key to find all event times for that key
+        val iterator = operations.prefixScan(key1)
+
+        val results = iterator.map { pair =>
+          val keyStr = pair.key.getString(0)
+          val partitionId = pair.key.getInt(1)
+          val eventTime = pair.eventTime
+          val value = pair.value.getInt(0)
+          (keyStr, partitionId, eventTime, value)
+        }.toList
+        iterator.close()
+
+        // Should return all entries with the same complete key but different event times
+        assert(results.length === 3)
+
+        // Verify results are ordered by event time (ascending)
+        val eventTimes = results.map(_._3)
+        assert(
+          eventTimes === Seq(1000L, 2000L, 3000L),
+          "Results should be ordered by event time"
+        )
+
+        // Verify all expected entries are present
+        assert(results(0) === (("key1", 1, 1000L, 100)))
+        assert(results(1) === (("key1", 1, 2000L, 101)))
+        assert(results(2) === (("key1", 1, 3000L, 102)))
+
+        // Should not contain key2
+        assert(!results.exists(_._1 == "key2"))
+      }
+    }
+
+    test(s"Event time as postfix: prefix scan with multiple values (encoding = $encoding)") {
+      tryWithProviderResource(
+        newStoreProviderWithEventTime(
+          encoderType = "postfix",
+          useMultipleValuesPerKey = true,
+          dataEncoding = encoding
+        )
+      ) { provider =>
+        val operations = getEventTimeAwareOps(
+          provider,
+          encoderType = "postfix",
+          useMultipleValuesPerKey = true
+        )
+
+        // Put multiple values for the same key at different event times
+        val key1 = keyToRow("key1", 1)
+
+        // Insert in non-sorted order to verify ordering by event time
+        val values2 = Array(valueToRow(200), valueToRow(201))
+        operations.putList(key1, 3000L, values2)
+
+        val values1 = Array(valueToRow(100), valueToRow(101))
+        operations.putList(key1, 1000L, values1)
+
+        val values3 = Array(valueToRow(300), valueToRow(301))
+        operations.putList(key1, 2000L, values3)
+
+        // Different key - should not be returned
+        val key2 = keyToRow("key2", 1)
+        val values4 = Array(valueToRow(400))
+        operations.putList(key2, 1500L, values4)
+
+        // Test prefixScanWithMultiValues - pass complete key to find all event times
+        val iterator = operations.prefixScanWithMultiValues(key1)
+
+        val results = iterator.map { pair =>
+          val keyStr = pair.key.getString(0)
+          val partitionId = pair.key.getInt(1)
+          val eventTime = pair.eventTime
+          val value = pair.value.getInt(0)
+          (keyStr, partitionId, eventTime, value)
+        }.toList
+        iterator.close()
+
+        // Should return all individual values for key1 across different event times
+        assert(results.length === 6) // 2 values at each of 3 event times
+
+        // Verify results are ordered by event time (ascending)
+        // Group by event time to verify ordering
+        val eventTimes = results.map(_._3)
+        val distinctEventTimes = eventTimes.distinct
+        assert(
+          distinctEventTimes === Seq(1000L, 2000L, 3000L),
+          "Results should be ordered by event time"
+        )
+
+        // Verify the first 2 results are from time 1000L
+        assert(results.take(2).forall(_._3 === 1000L))
+        assert(results.take(2).map(_._4).toSet === Set(100, 101))
+
+        // Verify the next 2 results are from time 2000L
+        assert(results.slice(2, 4).forall(_._3 === 2000L))
+        assert(results.slice(2, 4).map(_._4).toSet === Set(300, 301))
+
+        // Verify the last 2 results are from time 3000L
+        assert(results.slice(4, 6).forall(_._3 === 3000L))
+        assert(results.slice(4, 6).map(_._4).toSet === Set(200, 201))
+
+        // Should not contain key2
+        assert(!results.exists(_._1 == "key2"))
+      }
+    }
+  }
+
+  test("EventTimeAwareStateOperations - error conditions") {
+    // Test with non-event-time encoder should fail
+    val provider = new RocksDBStateStoreProvider()
+    val stateStoreId = StateStoreId(newDir(), Random.nextInt(), 0)
+    val conf = new Configuration
+    conf.set(StreamExecution.RUN_ID_KEY, UUID.randomUUID().toString)
+
+    val storeConf = new StateStoreConf(SQLConf.get)
+    provider.init(
+      stateStoreId,
+      keySchema,
+      valueSchema,
+      NoPrefixKeyStateEncoderSpec(
+        keySchema
+      ), // This doesn't support event time
+      useColumnFamilies = true,
+      storeConf,
+      conf,
+      useMultipleValuesPerKey = false
+    )
+
+    tryWithProviderResource(provider) { provider =>
+      val store =
+        provider.getStore(0).asInstanceOf[provider.RocksDBStateStore]
+
+      store.createColFamilyIfAbsent(
+        testColFamily,
+        keySchema,
+        valueSchema,
+        NoPrefixKeyStateEncoderSpec(keySchema),
+        useMultipleValuesPerKey = false
+      )
+
+      // Should throw exception when trying to create event time operations
+      intercept[IllegalArgumentException] {
+        store.initiateEventTimeAwareStateOperations(testColFamily)
+      }
+    }
+  }
+
+  test("EventTimeAwareStateOperations - column family name property") {
+    tryWithProviderResource(newStoreProviderWithEventTime()) { provider =>
+      val operations =
+        getEventTimeAwareOps(provider, columnFamily = "custom_cf")
+
+      assert(operations.columnFamilyName === "custom_cf")
+    }
+  }
+
+  // Helper method for resource management
+  private def tryWithProviderResource[T](provider: RocksDBStateStoreProvider)
+      (f: RocksDBStateStoreProvider => T): T = {
+    try {
+      f(provider)
+    } finally {
+      provider.close()
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBEventTimeAwareStateOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBEventTimeAwareStateOperationsSuite.scala
@@ -62,92 +62,6 @@ class RocksDBEventTimeAwareStateOperationsSuite extends SharedSparkSession
     super.afterEach()
   }
 
-  // Helper methods to create test data
-  private def stringToRow(s: String): UnsafeRow = {
-    UnsafeProjection.create(Array[DataType](StringType))
-      .apply(InternalRow(UTF8String.fromString(s)))
-  }
-
-  private def intToRow(i: Int): UnsafeRow = {
-    UnsafeProjection.create(Array[DataType](IntegerType)).apply(InternalRow(i))
-  }
-
-  private def keyToRow(key: String, partitionId: Int): UnsafeRow = {
-    UnsafeProjection.create(keySchema)
-      .apply(InternalRow(UTF8String.fromString(key), partitionId))
-  }
-
-  private def valueToRow(value: Int): UnsafeRow = {
-    UnsafeProjection.create(valueSchema).apply(InternalRow(value))
-  }
-
-  // Helper to create a new store provider with event time encoder
-  private def newStoreProviderWithEventTime(
-      encoderType: String = "prefix", // "prefix" or "postfix"
-      useColumnFamilies: Boolean = true,
-      useMultipleValuesPerKey: Boolean = false,
-      dataEncoding: String = "unsaferow"): RocksDBStateStoreProvider = {
-
-    val keyStateEncoderSpec = encoderType match {
-      case "prefix" => EventTimeAsPrefixStateEncoderSpec(keySchema)
-      case "postfix" => EventTimeAsPostfixStateEncoderSpec(keySchema)
-      case _ => throw new IllegalArgumentException(s"Unknown encoder type: $encoderType")
-    }
-
-    // Create a copy of SQLConf and set data encoding format on it
-    val sqlConf = SQLConf.get.clone()
-    sqlConf.setConfString(
-      "spark.sql.streaming.stateStore.encodingFormat",
-      dataEncoding)
-
-    val provider = new RocksDBStateStoreProvider()
-    val stateStoreId = StateStoreId(newDir(), Random.nextInt(), 0)
-    val conf = new Configuration
-    conf.set(StreamExecution.RUN_ID_KEY, UUID.randomUUID().toString)
-
-    val storeConf = new StateStoreConf(sqlConf)
-    provider.init(
-      stateStoreId,
-      keySchema,
-      valueSchema,
-      keyStateEncoderSpec,
-      useColumnFamilies,
-      storeConf,
-      conf,
-      useMultipleValuesPerKey)
-
-    provider
-  }
-
-  // Helper to get event time aware state operations
-  // Returns both the store and operations so caller can manage store lifecycle
-  private def getEventTimeAwareOps(
-      provider: RocksDBStateStoreProvider,
-      version: Long = 0,
-      columnFamily: String = testColFamily,
-      encoderType: String = "prefix",
-      useMultipleValuesPerKey: Boolean = false): (StateStore, EventTimeAwareStateOperations) = {
-
-    val keyStateEncoderSpec = encoderType match {
-      case "prefix" => EventTimeAsPrefixStateEncoderSpec(keySchema)
-      case "postfix" => EventTimeAsPostfixStateEncoderSpec(keySchema)
-      case _ => throw new IllegalArgumentException(s"Unknown encoder type: $encoderType")
-    }
-
-    val store = provider.getStore(version).asInstanceOf[provider.RocksDBStateStore]
-
-    // Create column family for testing
-    store.createColFamilyIfAbsent(
-      columnFamily,
-      keySchema,
-      valueSchema,
-      keyStateEncoderSpec,
-      useMultipleValuesPerKey = useMultipleValuesPerKey)
-
-    val operations = store.initiateEventTimeAwareStateOperations(columnFamily)
-    (store, operations)
-  }
-
   private def newDir(): String = Utils.createTempDir().getCanonicalPath
 
   Seq("unsaferow", "avro").foreach { encoding =>
@@ -337,48 +251,52 @@ class RocksDBEventTimeAwareStateOperationsSuite extends SharedSparkSession
       tryWithProviderResource(
         newStoreProviderWithEventTime(
           encoderType = "prefix", dataEncoding = encoding)) { provider =>
-        val operations = getEventTimeAwareOps(provider)
+        val (store, operations) = getEventTimeAwareOps(provider)
 
-        val entries = Map(
-          (keyToRow("key1", 1), 2000L) -> valueToRow(100),
-          (keyToRow("key2", 1), 1500L) -> valueToRow(200),
-          (keyToRow("key1", 2), 1000L) -> valueToRow(300)
-        )
+        try {
+          val entries = Map(
+            (keyToRow("key1", 1), 2000L) -> valueToRow(100),
+            (keyToRow("key2", 1), 1500L) -> valueToRow(200),
+            (keyToRow("key1", 2), 1000L) -> valueToRow(300)
+          )
 
-        // Put all entries (in non-sorted order)
-        entries.foreach { case ((key, eventTime), value) =>
-          operations.put(key, eventTime, value)
+          // Put all entries (in non-sorted order)
+          entries.foreach { case ((key, eventTime), value) =>
+            operations.put(key, eventTime, value)
+          }
+
+          // Test iterator - should return all entries ordered by event time
+          val iterator = operations.iterator()
+          val results = iterator.map { pair =>
+            val keyString = pair.key.getString(0)
+            val partitionId = pair.key.getInt(1)
+            val eventTime = pair.eventTime
+            val value = pair.value.getInt(0)
+            (keyString, partitionId, eventTime, value)
+          }.toList
+
+          iterator.close()
+
+          assert(results.length === 3)
+
+          // Verify results are ordered by event time (ascending)
+          val eventTimes = results.map(_._3)
+          assert(
+            eventTimes === Seq(1000L, 1500L, 2000L),
+            "Results should be ordered by event time"
+          )
+
+          // Verify all expected entries are present
+          val retrievedEntries = results.map {
+            case (key, partId, time, value) =>
+              ((key, partId, time), value)
+          }.toMap
+          assert(retrievedEntries((("key1", 2, 1000L))) === 300)
+          assert(retrievedEntries((("key2", 1, 1500L))) === 200)
+          assert(retrievedEntries((("key1", 1, 2000L))) === 100)
+        } finally {
+          store.abort()
         }
-
-        // Test iterator - should return all entries ordered by event time
-        val iterator = operations.iterator()
-        val results = iterator.map { pair =>
-          val keyString = pair.key.getString(0)
-          val partitionId = pair.key.getInt(1)
-          val eventTime = pair.eventTime
-          val value = pair.value.getInt(0)
-          (keyString, partitionId, eventTime, value)
-        }.toList
-
-        iterator.close()
-
-        assert(results.length === 3)
-
-        // Verify results are ordered by event time (ascending)
-        val eventTimes = results.map(_._3)
-        assert(
-          eventTimes === Seq(1000L, 1500L, 2000L),
-          "Results should be ordered by event time"
-        )
-
-        // Verify all expected entries are present
-        val retrievedEntries = results.map {
-          case (key, partId, time, value) =>
-            ((key, partId, time), value)
-        }.toMap
-        assert(retrievedEntries((("key1", 2, 1000L))) === 300)
-        assert(retrievedEntries((("key2", 1, 1500L))) === 200)
-        assert(retrievedEntries((("key1", 1, 2000L))) === 100)
       }
     }
 
@@ -389,30 +307,33 @@ class RocksDBEventTimeAwareStateOperationsSuite extends SharedSparkSession
           useMultipleValuesPerKey = true,
           dataEncoding = encoding)
       ) { provider =>
-        val operations =
-          getEventTimeAwareOps(provider, useMultipleValuesPerKey = true)
+        val (store, operations) = getEventTimeAwareOps(provider, useMultipleValuesPerKey = true)
 
-        val key1 = keyToRow("key1", 1)
-        val values1 = Array(valueToRow(100), valueToRow(101))
-        val key2 = keyToRow("key2", 1)
-        val values2 = Array(valueToRow(200))
-        val eventTime = 1000L
+        try {
+          val key1 = keyToRow("key1", 1)
+          val values1 = Array(valueToRow(100), valueToRow(101))
+          val key2 = keyToRow("key2", 1)
+          val values2 = Array(valueToRow(200))
+          val eventTime = 1000L
 
-        operations.putList(key1, eventTime, values1)
-        operations.putList(key2, eventTime, values2)
+          operations.putList(key1, eventTime, values1)
+          operations.putList(key2, eventTime, values2)
 
-        // Test iteratorWithMultiValues
-        val iterator = operations.iteratorWithMultiValues()
-        val retrievedValues = iterator.map { pair =>
-          pair.value.getInt(0)
-        }.toList
+          // Test iteratorWithMultiValues
+          val iterator = operations.iteratorWithMultiValues()
+          val retrievedValues = iterator.map { pair =>
+            pair.value.getInt(0)
+          }.toList
 
-        iterator.close()
+          iterator.close()
 
-        assert(
-          retrievedValues.length === 3
-        ) // 2 values from key1 + 1 value from key2
-        assert(retrievedValues.toSet === Set(100, 101, 200))
+          assert(
+            retrievedValues.length === 3
+          ) // 2 values from key1 + 1 value from key2
+          assert(retrievedValues.toSet === Set(100, 101, 200))
+        } finally {
+          store.abort()
+        }
       }
     }
 
@@ -422,51 +343,54 @@ class RocksDBEventTimeAwareStateOperationsSuite extends SharedSparkSession
       tryWithProviderResource(
         newStoreProviderWithEventTime(encoderType = "postfix", dataEncoding = encoding)
       ) { provider =>
-        val operations =
-          getEventTimeAwareOps(provider, encoderType = "postfix")
+        val (store, operations) = getEventTimeAwareOps(provider, encoderType = "postfix")
 
-        // Put entries with the same complete key but different event times
-        // Prefix scan should find all entries with the same key across different event times
-        val key1 = keyToRow("key1", 1)
-        val key2 = keyToRow("key2", 1) // Different key
+        try {
+          // Put entries with the same complete key but different event times
+          // Prefix scan should find all entries with the same key across different event times
+          val key1 = keyToRow("key1", 1)
+          val key2 = keyToRow("key2", 1) // Different key
 
-        // Insert in non-sorted order to verify that prefix scan returns them sorted by time
-        operations.put(key1, 3000L, valueToRow(102))
-        operations.put(key1, 1000L, valueToRow(100))
-        operations.put(key1, 2000L, valueToRow(101))
+          // Insert in non-sorted order to verify that prefix scan returns them sorted by time
+          operations.put(key1, 3000L, valueToRow(102))
+          operations.put(key1, 1000L, valueToRow(100))
+          operations.put(key1, 2000L, valueToRow(101))
 
-        // Different key (key2, 1) - should not be returned
-        operations.put(key2, 1500L, valueToRow(200))
+          // Different key (key2, 1) - should not be returned
+          operations.put(key2, 1500L, valueToRow(200))
 
-        // Test prefixScan - pass the complete key to find all event times for that key
-        val iterator = operations.prefixScan(key1)
+          // Test prefixScan - pass the complete key to find all event times for that key
+          val iterator = operations.prefixScan(key1)
 
-        val results = iterator.map { pair =>
-          val keyStr = pair.key.getString(0)
-          val partitionId = pair.key.getInt(1)
-          val eventTime = pair.eventTime
-          val value = pair.value.getInt(0)
-          (keyStr, partitionId, eventTime, value)
-        }.toList
-        iterator.close()
+          val results = iterator.map { pair =>
+            val keyStr = pair.key.getString(0)
+            val partitionId = pair.key.getInt(1)
+            val eventTime = pair.eventTime
+            val value = pair.value.getInt(0)
+            (keyStr, partitionId, eventTime, value)
+          }.toList
+          iterator.close()
 
-        // Should return all entries with the same complete key but different event times
-        assert(results.length === 3)
+          // Should return all entries with the same complete key but different event times
+          assert(results.length === 3)
 
-        // Verify results are ordered by event time (ascending)
-        val eventTimes = results.map(_._3)
-        assert(
-          eventTimes === Seq(1000L, 2000L, 3000L),
-          "Results should be ordered by event time"
-        )
+          // Verify results are ordered by event time (ascending)
+          val eventTimes = results.map(_._3)
+          assert(
+            eventTimes === Seq(1000L, 2000L, 3000L),
+            "Results should be ordered by event time"
+          )
 
-        // Verify all expected entries are present
-        assert(results(0) === (("key1", 1, 1000L, 100)))
-        assert(results(1) === (("key1", 1, 2000L, 101)))
-        assert(results(2) === (("key1", 1, 3000L, 102)))
+          // Verify all expected entries are present
+          assert(results(0) === (("key1", 1, 1000L, 100)))
+          assert(results(1) === (("key1", 1, 2000L, 101)))
+          assert(results(2) === (("key1", 1, 3000L, 102)))
 
-        // Should not contain key2
-        assert(!results.exists(_._1 == "key2"))
+          // Should not contain key2
+          assert(!results.exists(_._1 == "key2"))
+        } finally {
+          store.abort()
+        }
       }
     }
 
@@ -478,68 +402,72 @@ class RocksDBEventTimeAwareStateOperationsSuite extends SharedSparkSession
           dataEncoding = encoding
         )
       ) { provider =>
-        val operations = getEventTimeAwareOps(
+        val (store, operations) = getEventTimeAwareOps(
           provider,
           encoderType = "postfix",
           useMultipleValuesPerKey = true
         )
 
-        // Put multiple values for the same key at different event times
-        val key1 = keyToRow("key1", 1)
+        try {
+          // Put multiple values for the same key at different event times
+          val key1 = keyToRow("key1", 1)
 
-        // Insert in non-sorted order to verify ordering by event time
-        val values2 = Array(valueToRow(200), valueToRow(201))
-        operations.putList(key1, 3000L, values2)
+          // Insert in non-sorted order to verify ordering by event time
+          val values2 = Array(valueToRow(200), valueToRow(201))
+          operations.putList(key1, 3000L, values2)
 
-        val values1 = Array(valueToRow(100), valueToRow(101))
-        operations.putList(key1, 1000L, values1)
+          val values1 = Array(valueToRow(100), valueToRow(101))
+          operations.putList(key1, 1000L, values1)
 
-        val values3 = Array(valueToRow(300), valueToRow(301))
-        operations.putList(key1, 2000L, values3)
+          val values3 = Array(valueToRow(300), valueToRow(301))
+          operations.putList(key1, 2000L, values3)
 
-        // Different key - should not be returned
-        val key2 = keyToRow("key2", 1)
-        val values4 = Array(valueToRow(400))
-        operations.putList(key2, 1500L, values4)
+          // Different key - should not be returned
+          val key2 = keyToRow("key2", 1)
+          val values4 = Array(valueToRow(400))
+          operations.putList(key2, 1500L, values4)
 
-        // Test prefixScanWithMultiValues - pass complete key to find all event times
-        val iterator = operations.prefixScanWithMultiValues(key1)
+          // Test prefixScanWithMultiValues - pass complete key to find all event times
+          val iterator = operations.prefixScanWithMultiValues(key1)
 
-        val results = iterator.map { pair =>
-          val keyStr = pair.key.getString(0)
-          val partitionId = pair.key.getInt(1)
-          val eventTime = pair.eventTime
-          val value = pair.value.getInt(0)
-          (keyStr, partitionId, eventTime, value)
-        }.toList
-        iterator.close()
+          val results = iterator.map { pair =>
+            val keyStr = pair.key.getString(0)
+            val partitionId = pair.key.getInt(1)
+            val eventTime = pair.eventTime
+            val value = pair.value.getInt(0)
+            (keyStr, partitionId, eventTime, value)
+          }.toList
+          iterator.close()
 
-        // Should return all individual values for key1 across different event times
-        assert(results.length === 6) // 2 values at each of 3 event times
+          // Should return all individual values for key1 across different event times
+          assert(results.length === 6) // 2 values at each of 3 event times
 
-        // Verify results are ordered by event time (ascending)
-        // Group by event time to verify ordering
-        val eventTimes = results.map(_._3)
-        val distinctEventTimes = eventTimes.distinct
-        assert(
-          distinctEventTimes === Seq(1000L, 2000L, 3000L),
-          "Results should be ordered by event time"
-        )
+          // Verify results are ordered by event time (ascending)
+          // Group by event time to verify ordering
+          val eventTimes = results.map(_._3)
+          val distinctEventTimes = eventTimes.distinct
+          assert(
+            distinctEventTimes === Seq(1000L, 2000L, 3000L),
+            "Results should be ordered by event time"
+          )
 
-        // Verify the first 2 results are from time 1000L
-        assert(results.take(2).forall(_._3 === 1000L))
-        assert(results.take(2).map(_._4).toSet === Set(100, 101))
+          // Verify the first 2 results are from time 1000L
+          assert(results.take(2).forall(_._3 === 1000L))
+          assert(results.take(2).map(_._4).toSet === Set(100, 101))
 
-        // Verify the next 2 results are from time 2000L
-        assert(results.slice(2, 4).forall(_._3 === 2000L))
-        assert(results.slice(2, 4).map(_._4).toSet === Set(300, 301))
+          // Verify the next 2 results are from time 2000L
+          assert(results.slice(2, 4).forall(_._3 === 2000L))
+          assert(results.slice(2, 4).map(_._4).toSet === Set(300, 301))
 
-        // Verify the last 2 results are from time 3000L
-        assert(results.slice(4, 6).forall(_._3 === 3000L))
-        assert(results.slice(4, 6).map(_._4).toSet === Set(200, 201))
+          // Verify the last 2 results are from time 3000L
+          assert(results.slice(4, 6).forall(_._3 === 3000L))
+          assert(results.slice(4, 6).map(_._4).toSet === Set(200, 201))
 
-        // Should not contain key2
-        assert(!results.exists(_._1 == "key2"))
+          // Should not contain key2
+          assert(!results.exists(_._1 == "key2"))
+        } finally {
+          store.abort()
+        }
       }
     }
   }
@@ -586,11 +514,91 @@ class RocksDBEventTimeAwareStateOperationsSuite extends SharedSparkSession
 
   test("EventTimeAwareStateOperations - column family name property") {
     tryWithProviderResource(newStoreProviderWithEventTime()) { provider =>
-      val operations =
-        getEventTimeAwareOps(provider, columnFamily = "custom_cf")
+      val (store, operations) = getEventTimeAwareOps(provider, columnFamily = "custom_cf")
 
-      assert(operations.columnFamilyName === "custom_cf")
+      try {
+        assert(operations.columnFamilyName === "custom_cf")
+      } finally {
+        store.abort()
+      }
     }
+  }
+
+  // Helper methods to create test data
+  private def keyToRow(key: String, partitionId: Int): UnsafeRow = {
+    UnsafeProjection.create(keySchema)
+      .apply(InternalRow(UTF8String.fromString(key), partitionId))
+  }
+
+  private def valueToRow(value: Int): UnsafeRow = {
+    UnsafeProjection.create(valueSchema).apply(InternalRow(value))
+  }
+
+  // Helper to create a new store provider with event time encoder
+  private def newStoreProviderWithEventTime(
+      encoderType: String = "prefix", // "prefix" or "postfix"
+      useColumnFamilies: Boolean = true,
+      useMultipleValuesPerKey: Boolean = false,
+      dataEncoding: String = "unsaferow"): RocksDBStateStoreProvider = {
+
+    val keyStateEncoderSpec = encoderType match {
+      case "prefix" => EventTimeAsPrefixStateEncoderSpec(keySchema)
+      case "postfix" => EventTimeAsPostfixStateEncoderSpec(keySchema)
+      case _ => throw new IllegalArgumentException(s"Unknown encoder type: $encoderType")
+    }
+
+    // Create a copy of SQLConf and set data encoding format on it
+    val sqlConf = SQLConf.get.clone()
+    sqlConf.setConfString(
+      "spark.sql.streaming.stateStore.encodingFormat",
+      dataEncoding)
+
+    val provider = new RocksDBStateStoreProvider()
+    val stateStoreId = StateStoreId(newDir(), Random.nextInt(), 0)
+    val conf = new Configuration
+    conf.set(StreamExecution.RUN_ID_KEY, UUID.randomUUID().toString)
+
+    val storeConf = new StateStoreConf(sqlConf)
+    provider.init(
+      stateStoreId,
+      keySchema,
+      valueSchema,
+      keyStateEncoderSpec,
+      useColumnFamilies,
+      storeConf,
+      conf,
+      useMultipleValuesPerKey)
+
+    provider
+  }
+
+  // Helper to get event time aware state operations
+  // Returns both the store and operations so caller can manage store lifecycle
+  private def getEventTimeAwareOps(
+      provider: RocksDBStateStoreProvider,
+      version: Long = 0,
+      columnFamily: String = testColFamily,
+      encoderType: String = "prefix",
+      useMultipleValuesPerKey: Boolean = false): (StateStore, EventTimeAwareStateOperations) = {
+
+    val keyStateEncoderSpec = encoderType match {
+      case "prefix" => EventTimeAsPrefixStateEncoderSpec(keySchema)
+      case "postfix" => EventTimeAsPostfixStateEncoderSpec(keySchema)
+      case _ => throw new IllegalArgumentException(s"Unknown encoder type: $encoderType")
+    }
+
+    val store = provider.getStore(version).asInstanceOf[provider.RocksDBStateStore]
+
+    // Create column family for testing
+    store.createColFamilyIfAbsent(
+      columnFamily,
+      keySchema,
+      valueSchema,
+      keyStateEncoderSpec,
+      useMultipleValuesPerKey = useMultipleValuesPerKey)
+
+    val operations = store.initiateEventTimeAwareStateOperations(columnFamily)
+    (store, operations)
   }
 
   // Helper method for resource management

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBEventTimeAwareStateOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBEventTimeAwareStateOperationsSuite.scala
@@ -64,7 +64,8 @@ class RocksDBEventTimeAwareStateOperationsSuite extends SharedSparkSession
 
   private def newDir(): String = Utils.createTempDir().getCanonicalPath
 
-  Seq("unsaferow", "avro").foreach { encoding =>
+  // TODO: Address the new state format with Avro and enable the test with Avro encoding
+  Seq("unsaferow").foreach { encoding =>
     Seq("prefix", "postfix").foreach { encoderType =>
       test(s"Event time as $encoderType: basic put and get operations (encoding = $encoding)") {
         tryWithProviderResource(
@@ -246,7 +247,8 @@ class RocksDBEventTimeAwareStateOperationsSuite extends SharedSparkSession
     }
   }
 
-  Seq("unsaferow", "avro").foreach { encoding =>
+  // TODO: Address the new state format with Avro and enable the test with Avro encoding
+  Seq("unsaferow").foreach { encoding =>
     test(s"Event time as prefix: iterator operations (encoding = $encoding)") {
       tryWithProviderResource(
         newStoreProviderWithEventTime(
@@ -509,6 +511,8 @@ class RocksDBEventTimeAwareStateOperationsSuite extends SharedSparkSession
       intercept[IllegalArgumentException] {
         store.initiateEventTimeAwareStateOperations(testColFamily)
       }
+
+      store.abort()
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreCheckpointFormatV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreCheckpointFormatV2Suite.scala
@@ -166,6 +166,11 @@ case class CkptIdCollectingStateStoreWrapper(innerStore: StateStore) extends Sta
     ret
   }
   override def hasCommitted: Boolean = innerStore.hasCommitted
+
+  override def initiateEventTimeAwareStateOperations(
+      columnFamilyName: String): EventTimeAwareStateOperations = {
+    innerStore.initiateEventTimeAwareStateOperations(columnFamilyName)
+  }
 }
 
 class CkptIdCollectingStateStoreProviderWrapper extends StateStoreProvider {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to make changes to state store layer to introduce key encodings which include "event time" as the first class.

Proposed key encodings:

* `EventTimeAsPrefixStateEncoderSpec`
  * Place event time as a prefix, and key as remaining part of serialized format
* `EventTimeAsPostfixStateEncoderSpec`
  * Place key first, and event time as a postfix of serialized format

Event time is encoded as it is, the binary format of 8 bytes long, as "big endian", which ensures the natural ordering of long type. The serialization format of the key is the same, e.g. for UnsafeRow, same as underlying binary format.

These encodings are specification of prefix and range key encodings:

* `EventTimeAsPrefixStateEncoderSpec` provides the range scan with event time.
* `EventTimeAsPostfixStateEncoderSpec` provides the prefix scan with the key, additionally provides the range scan with the remaining event time. NOTE: The range scan with event time is only scoped to the same key.

Compared to the prefix/range key encoding, this can eliminate the overhead of combining two UnsafeRows, 12 bytes in each key in overall (8 bytes of null-tracking bitset, 4 bytes of storing length for one of two UnsafeRows). It can also skip projection(s) from deserialization as well.

To maximize the benefit, this PR also proposes to define a new set of state store operations (API) to receive an event time parameter separately or provide an event time as a part of result for the methods. This is to make the spec easy to use by the caller via removing the necessity of combining key and event time into a single UnsafeRow. Since this decision duplicates the whole operations and the new key encoder specs do not work properly with existing set of state store operations, this PR introduces a new trait (`EventTimeAwareStateOperations`) to place the new set of APIs and callers are expected to obtain the implementation of the trait in prior to work with the CF with new key encoder spec.

The API to obtain the implementation of the trait is following:

`initiateEventTimeAwareStateOperations(columnFamilyName): EventTimeAwareStateOperations`

This PR also proposes to change `RocksDBKeyStateEncoder` to handle the encode/decode with event time. It'd be ideal to have another interface for event time aware encoders, but the existing codebase is quite tied to `RocksDBKeyStateEncoder`, so this PR simply defines additional methods to cover the new type of encoding. The new method `supportEventTime` will serve the intention to isolate the encoding for "key only" vs "key + event time".

The change is big already, so this PR only enables the new key encoding with UnsafeRow. Supporting Avro will be a follow up work.

### Why are the changes needed?

The existing key encodings are too general to serve the same with noticeable overheads, in terms of additional bytes on serialized format, as well as unnecessary projections to combine key and event time and tear down. The proposed key encodings will do the same with minimized overhead, given the fact it only needs to handle event time (8 bytes long, no negative value) along with the key.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New test suite.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: claude-4.5-sonnet

The above is used for creating a new test suite. All other parts aren't generated by LLM.