### PR TITLE
[WIP] Implement the new state format for stream-stream join based on event time aware key encodings

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/join/StreamingSymmetricHashJoinValueRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/join/StreamingSymmetricHashJoinValueRowConverter.scala
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.streaming.operators.stateful.join
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Literal, UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.execution.streaming.operators.stateful.join.SymmetricHashJoinStateManager.ValueAndMatchPair
+import org.apache.spark.sql.types.BooleanType
+
+/**
+ * Converter between the value row stored in state store and the (actual value, match) pair.
+ */
+trait StreamingSymmetricHashJoinValueRowConverter {
+  /** Defines the schema of the value row (the value side of K-V in state store). */
+  def valueAttributes: Seq[Attribute]
+
+  /**
+   * Convert the value row to (actual value, match) pair.
+   *
+   * NOTE: implementations should ensure the result row is NOT reused during execution, so
+   * that caller can safely read the value in any time.
+   */
+  def convertValue(value: UnsafeRow): ValueAndMatchPair
+
+  /**
+   * Build the value row from (actual value, match) pair. This is expected to be called just
+   * before storing to the state store.
+   *
+   * NOTE: depending on the implementation, the result row "may" be reused during execution
+   * (to avoid initialization of object), so the caller should ensure that the logic doesn't
+   * affect by such behavior. Call copy() against the result row if needed.
+   */
+  def convertToValueRow(value: UnsafeRow, matched: Boolean): UnsafeRow
+}
+
+class StreamingSymmetricHashJoinValueRowConverterFormatV1(
+    inputValueAttributes: Seq[Attribute]) extends StreamingSymmetricHashJoinValueRowConverter {
+  override val valueAttributes: Seq[Attribute] = inputValueAttributes
+
+  override def convertValue(value: UnsafeRow): ValueAndMatchPair = {
+    if (value != null) ValueAndMatchPair(value, false) else null
+  }
+
+  override def convertToValueRow(value: UnsafeRow, matched: Boolean): UnsafeRow = value
+}
+
+class StreamingSymmetricHashJoinValueRowConverterFormatV2(
+    inputValueAttributes: Seq[Attribute]) extends StreamingSymmetricHashJoinValueRowConverter {
+  private val valueWithMatchedExprs = inputValueAttributes :+ Literal(true)
+  private val indexOrdinalInValueWithMatchedRow = inputValueAttributes.size
+
+  private val valueWithMatchedRowGenerator = UnsafeProjection.create(valueWithMatchedExprs,
+    inputValueAttributes)
+
+  override val valueAttributes: Seq[Attribute] = inputValueAttributes :+
+    AttributeReference("matched", BooleanType)()
+
+  // Projection to generate key row from (value + matched) row
+  private val valueRowGenerator = UnsafeProjection.create(
+    inputValueAttributes, valueAttributes)
+
+  override def convertValue(value: UnsafeRow): ValueAndMatchPair = {
+    if (value != null) {
+      ValueAndMatchPair(valueRowGenerator(value).copy(),
+        value.getBoolean(indexOrdinalInValueWithMatchedRow))
+    } else {
+      null
+    }
+  }
+
+  override def convertToValueRow(value: UnsafeRow, matched: Boolean): UnsafeRow = {
+    val row = valueWithMatchedRowGenerator(value)
+    row.setBoolean(indexOrdinalInValueWithMatchedRow, matched)
+    row
+  }
+}
+
+object StreamingSymmetricHashJoinValueRowConverter {
+  def create(
+      inputValueAttributes: Seq[Attribute],
+      stateFormatVersion: Int): StreamingSymmetricHashJoinValueRowConverter = {
+    stateFormatVersion match {
+      case 1 => new StreamingSymmetricHashJoinValueRowConverterFormatV1(inputValueAttributes)
+      case 2 | 3 | 4 =>
+        new StreamingSymmetricHashJoinValueRowConverterFormatV2(inputValueAttributes)
+      case _ => throw new IllegalArgumentException ("Incorrect state format version! " +
+        s"version $stateFormatVersion")
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/SymmetricHashJoinStateManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/SymmetricHashJoinStateManagerSuite.scala
@@ -17,54 +17,220 @@
 
 package org.apache.spark.sql.execution.streaming.state
 
+import java.io.File
 import java.sql.Timestamp
 import java.util.UUID
 
 import org.apache.hadoop.conf.Configuration
 import org.scalatest.BeforeAndAfter
-import org.scalatest.PrivateMethodTester
 
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.expressions.{Attribute, BoundReference, Expression, GenericInternalRow, LessThanOrEqual, Literal, UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, BoundReference, Expression, GenericInternalRow, LessThanOrEqual, Literal, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.catalyst.expressions.codegen.GeneratePredicate
 import org.apache.spark.sql.catalyst.plans.logical.EventTimeWatermark
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.execution.metric.SQLMetric
-import org.apache.spark.sql.execution.streaming.operators.stateful.{StatefulOperatorStateInfo, StatefulOperatorsUtils, StatePartitionKeyExtractorFactory}
-import org.apache.spark.sql.execution.streaming.operators.stateful.join.{JoinStateManagerStoreGenerator, SymmetricHashJoinStateManager}
+import org.apache.spark.sql.execution.streaming.operators.stateful.StatefulOperatorStateInfo
+import org.apache.spark.sql.execution.streaming.operators.stateful.join.{JoinStateManagerStoreGenerator, SupportsEvictByCondition, SupportsEvictByTimestamp, SupportsIndexedKeys, SymmetricHashJoinStateManager}
 import org.apache.spark.sql.execution.streaming.operators.stateful.join.StreamingSymmetricHashJoinHelper.LeftSide
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.StreamTest
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
-class SymmetricHashJoinStateManagerSuite extends StreamTest with BeforeAndAfter
-  with PrivateMethodTester {
-
+abstract class SymmetricHashJoinStateManagerBaseSuite extends StreamTest with BeforeAndAfter {
   before {
     SparkSession.setActiveSession(spark) // set this before force initializing 'joinExec'
     spark.streams.stateStoreCoordinator // initialize the lazy coordinator
   }
 
-  SymmetricHashJoinStateManager.supportedVersions.foreach { version =>
-    test(s"StreamingJoinStateManager V${version} - all operations") {
-      testAllOperations(version)
+  protected def inputValueAttributes: Seq[AttributeReference]
+  protected def inputValueAttributesWithWatermark: AttributeReference
+  protected def joinKeyExpressions: Seq[Expression]
+
+  private def inputValueGen = UnsafeProjection.create(inputValueAttributes.map(_.dataType).toArray)
+  private def joinKeyGen = UnsafeProjection.create(joinKeyExpressions.map(_.dataType).toArray)
+
+  protected def toInputValue(key: Int, value: Int): UnsafeRow = {
+    inputValueGen.apply(new GenericInternalRow(Array[Any](key, value)))
+  }
+
+  protected def toJoinKeyRow(key: Int): UnsafeRow = {
+    joinKeyGen.apply(new GenericInternalRow(Array[Any](false, key, 10.0)))
+  }
+
+  protected def toValueInt(inputValueRow: UnsafeRow): Int = inputValueRow.getInt(1)
+
+  protected def append(key: Int, value: Int)
+                      (implicit manager: SymmetricHashJoinStateManager): Unit = {
+    // we only put matched = false for simplicity - StreamingJoinSuite will test the functionality
+    manager.append(toJoinKeyRow(key), toInputValue(key, value), matched = false)
+  }
+
+  protected def appendAndTest(key: Int, values: Int*)
+                             (implicit manager: SymmetricHashJoinStateManager): Unit = {
+    values.foreach { value => append(key, value)}
+    require(get(key) === values)
+  }
+
+  protected def getNumValues(key: Int)
+                            (implicit manager: SymmetricHashJoinStateManager): Int = {
+    manager.get(toJoinKeyRow(key)).size
+  }
+
+  protected def get(key: Int)(implicit manager: SymmetricHashJoinStateManager): Seq[Int] = {
+    manager.get(toJoinKeyRow(key)).map(toValueInt).toSeq.sorted
+  }
+
+  /** Remove keys (and corresponding values) where `time <= threshold` */
+  protected def removeByKey(threshold: Long)
+                           (implicit manager: SymmetricHashJoinStateManager): Unit = {
+    manager match {
+      case evictByTimestamp: SupportsEvictByTimestamp =>
+        evictByTimestamp.evictByTimestamp(threshold)
+
+      case evictByCondition: SupportsEvictByCondition =>
+        val expr =
+          LessThanOrEqual(
+            BoundReference(
+              1,
+              inputValueAttributesWithWatermark.dataType,
+              inputValueAttributesWithWatermark.nullable),
+            Literal(threshold))
+        evictByCondition.evictByKeyCondition(GeneratePredicate.generate(expr).eval _)
     }
   }
 
-  SymmetricHashJoinStateManager.supportedVersions.foreach { version =>
+  /** Remove values where `time <= threshold` */
+  protected def removeByValue(watermark: Long)
+                             (implicit manager: SymmetricHashJoinStateManager): Unit = {
+    manager match {
+      case evictByTimestamp: SupportsEvictByTimestamp =>
+        evictByTimestamp.evictByTimestamp(watermark)
+
+      case evictByCondition: SupportsEvictByCondition =>
+        val expr = LessThanOrEqual(inputValueAttributesWithWatermark, Literal(watermark))
+        evictByCondition.evictByValueCondition(
+          GeneratePredicate.generate(expr, inputValueAttributes).eval _)
+    }
+  }
+
+  protected def assertNumRows(stateFormatVersion: Int, target: Long)(
+    implicit manager: SymmetricHashJoinStateManager): Unit = {
+    // This suite originally uses HDFSBackStateStoreProvider, which provides instantaneous metrics
+    // for numRows.
+    // But for version 3 with virtual column families, RocksDBStateStoreProvider updates metrics
+    // asynchronously. This means the number of keys obtained from the metrics are very likely
+    // to be outdated right after a put/remove.
+    if (stateFormatVersion <= 2) {
+      assert(manager.metrics.numKeys == target)
+    }
+  }
+
+  protected def withJoinStateManager(
+      inputValueAttribs: Seq[Attribute],
+      joinKeyExprs: Seq[Expression],
+      stateFormatVersion: Int,
+      skipNullsForStreamStreamJoins: Boolean = false,
+      metric: Option[SQLMetric] = None)
+    (f: SymmetricHashJoinStateManager => Unit): Unit = {
+    // HDFS store providers do not support virtual column families
+    val storeProvider = if (stateFormatVersion >= 3) {
+      classOf[RocksDBStateStoreProvider].getName
+    } else {
+      classOf[HDFSBackedStateStoreProvider].getName
+    }
+    withTempDir { file =>
+      withSQLConf(
+        SQLConf.STATE_STORE_SKIP_NULLS_FOR_STREAM_STREAM_JOINS.key ->
+          skipNullsForStreamStreamJoins.toString,
+        SQLConf.STATE_STORE_PROVIDER_CLASS.key -> storeProvider
+      ) {
+        val storeConf = new StateStoreConf(spark.sessionState.conf)
+        val stateInfo = StatefulOperatorStateInfo(
+          file.getAbsolutePath, UUID.randomUUID, 0, 0, 5, None)
+        val manager = SymmetricHashJoinStateManager(
+          LeftSide, inputValueAttribs, joinKeyExprs, Some(stateInfo), storeConf, new Configuration,
+          partitionId = 0, None, None, stateFormatVersion, metric,
+          joinStoreGenerator = new JoinStateManagerStoreGenerator())
+        try {
+          f(manager)
+        } finally {
+          manager.abortIfNeeded()
+        }
+      }
+    }
+    StateStore.stop()
+  }
+
+  protected def withJoinStateManagerWithCheckpointDir(
+      inputValueAttribs: Seq[Attribute],
+      joinKeyExprs: Seq[Expression],
+      stateFormatVersion: Int,
+      checkpointDir: File,
+      storeVersion: Int,
+      changelogCheckpoint: Boolean,
+      skipNullsForStreamStreamJoins: Boolean = false,
+      metric: Option[SQLMetric] = None)
+    (f: SymmetricHashJoinStateManager => Unit): Unit = {
+    // HDFS store providers do not support virtual column families
+    val storeProvider = if (stateFormatVersion >= 3) {
+      classOf[RocksDBStateStoreProvider].getName
+    } else {
+      classOf[HDFSBackedStateStoreProvider].getName
+    }
+    withSQLConf(
+      SQLConf.STATE_STORE_SKIP_NULLS_FOR_STREAM_STREAM_JOINS.key ->
+        skipNullsForStreamStreamJoins.toString,
+      SQLConf.STATE_STORE_PROVIDER_CLASS.key -> storeProvider,
+      "spark.sql.streaming.stateStore.rocksdb.changelogCheckpointing.enabled" ->
+        changelogCheckpoint.toString
+    ) {
+      val storeConf = new StateStoreConf(spark.sessionState.conf)
+      val stateInfo = StatefulOperatorStateInfo(
+        checkpointDir.getAbsolutePath, UUID.randomUUID, 0, storeVersion, 5, None)
+      val manager = SymmetricHashJoinStateManager(
+        LeftSide, inputValueAttribs, joinKeyExprs, Some(stateInfo), storeConf, new Configuration,
+        partitionId = 0, None, None, stateFormatVersion, metric,
+        joinStoreGenerator = new JoinStateManagerStoreGenerator())
+      try {
+        f(manager)
+      } finally {
+        manager.abortIfNeeded()
+      }
+    }
+    StateStore.stop()
+  }
+}
+
+class SymmetricHashJoinStateManagerSuite extends SymmetricHashJoinStateManagerBaseSuite {
+  private val watermarkMetadata = new MetadataBuilder()
+    .putLong(EventTimeWatermark.delayKey, 10).build()
+  private val inputValueSchema = new StructType()
+    .add(StructField("key", IntegerType))
+    .add(StructField("time", IntegerType, metadata = watermarkMetadata))
+
+  override protected val inputValueAttributes = toAttributes(inputValueSchema)
+  override protected val inputValueAttributesWithWatermark = inputValueAttributes(1)
+  override protected val joinKeyExpressions = Seq[Expression](
+    Literal(false), inputValueAttributes(0), Literal(10.0))
+
+  // Below tests are not bound to version 4 as they are specifically for testing null handling
+  private val versionsInTest = Seq(1, 2, 3)
+
+  versionsInTest.foreach { version =>
     test(s"StreamingJoinStateManager V${version} - all operations with nulls") {
       testAllOperationsWithNulls(version)
     }
   }
 
-  SymmetricHashJoinStateManager.supportedVersions.foreach { version =>
+  versionsInTest.foreach { version =>
     test(s"StreamingJoinStateManager V${version} - all operations with nulls in middle") {
       testAllOperationsWithNullsInMiddle(version)
     }
   }
 
-  SymmetricHashJoinStateManager.supportedVersions.foreach { version =>
+  versionsInTest.foreach { version =>
     test(s"SPARK-35689: StreamingJoinStateManager V${version} - " +
         "printable key of keyWithIndexToValue") {
 
@@ -75,83 +241,23 @@ class SymmetricHashJoinStateManagerSuite extends StreamTest with BeforeAndAfter
         Literal(Timestamp.valueOf("2021-6-8 10:25:50")))
       val keyGen = UnsafeProjection.create(keyExprs.map(_.dataType).toArray)
 
-      withJoinStateManager(inputValueAttribs, keyExprs, version) { manager =>
+      withJoinStateManager(inputValueAttributes, keyExprs, version) { manager =>
+        assert(manager.isInstanceOf[SupportsIndexedKeys])
+
         val currentKey = keyGen.apply(new GenericInternalRow(Array[Any](
           false, 10.0, UTF8String.fromString("string"),
           Timestamp.valueOf("2021-6-8 10:25:50").getTime)))
 
-        val projectedRow = manager.getInternalRowOfKeyWithIndex(currentKey)
+        val projectedRow = manager.asInstanceOf[SupportsIndexedKeys]
+          .getInternalRowOfKeyWithIndex(currentKey)
         assert(s"$projectedRow" == "[false,10.0,string,1623173150000]")
       }
     }
   }
 
-  SymmetricHashJoinStateManager.supportedVersions.foreach { version =>
-    test(s"Partition key extraction - SymmetricHashJoinStateManager v$version") {
-      testPartitionKeyExtraction(version)
-    }
-  }
-
-  private def testAllOperations(stateFormatVersion: Int): Unit = {
-    withJoinStateManager(inputValueAttribs, joinKeyExprs, stateFormatVersion) { manager =>
-      implicit val mgr = manager
-
-      assert(get(20) === Seq.empty)     // initially empty
-      append(20, 2)
-      assert(get(20) === Seq(2))        // should first value correctly
-      assertNumRows(stateFormatVersion, 1)
-
-      append(20, 3)
-      assert(get(20) === Seq(2, 3))     // should append new values
-      append(20, 3)
-      assert(get(20) === Seq(2, 3, 3))  // should append another copy if same value added again
-      assertNumRows(stateFormatVersion, 3)
-
-      assert(get(30) === Seq.empty)
-      append(30, 1)
-      assert(get(30) === Seq(1))
-      assert(get(20) === Seq(2, 3, 3))  // add another key-value should not affect existing ones
-      assertNumRows(stateFormatVersion, 4)
-
-      removeByKey(25)
-      assert(get(20) === Seq.empty)
-      assert(get(30) === Seq(1))        // should remove 20, not 30
-      assertNumRows(stateFormatVersion, 1)
-
-      removeByKey(30)
-      assert(get(30) === Seq.empty)     // should remove 30
-      assertNumRows(stateFormatVersion, 0)
-
-      appendAndTest(40, 100, 200, 300)
-      appendAndTest(50, 125)
-      appendAndTest(60, 275)              // prepare for testing removeByValue
-      assertNumRows(stateFormatVersion, 5)
-
-      removeByValue(125)
-      assert(get(40) === Seq(200, 300))
-      assert(get(50) === Seq.empty)
-      assert(get(60) === Seq(275))        // should remove only some values, not all
-      assertNumRows(stateFormatVersion, 3)
-
-      append(40, 50)
-      assert(get(40) === Seq(50, 200, 300))
-      assertNumRows(stateFormatVersion, 4)
-
-      removeByValue(200)
-      assert(get(40) === Seq(300))
-      assert(get(60) === Seq(275))        // should remove only some values, not all
-      assertNumRows(stateFormatVersion, 2)
-
-      removeByValue(300)
-      assert(get(40) === Seq.empty)
-      assert(get(60) === Seq.empty)       // should remove all values now
-      assertNumRows(stateFormatVersion, 0)
-    }
-  }
-
   /* Test removeByValue with nulls simulated by updating numValues on the state manager */
   private def testAllOperationsWithNulls(stateFormatVersion: Int): Unit = {
-    withJoinStateManager(inputValueAttribs, joinKeyExprs, stateFormatVersion) { manager =>
+    withJoinStateManager(inputValueAttributes, joinKeyExpressions, stateFormatVersion) { manager =>
       implicit val mgr = manager
 
       appendAndTest(40, 100, 200, 300)
@@ -189,7 +295,7 @@ class SymmetricHashJoinStateManagerSuite extends StreamTest with BeforeAndAfter
   private def testAllOperationsWithNullsInMiddle(stateFormatVersion: Int): Unit = {
     // Test with skipNullsForStreamStreamJoins set to false which would throw a
     // NullPointerException while iterating and also return null values as part of get
-    withJoinStateManager(inputValueAttribs, joinKeyExprs, stateFormatVersion) { manager =>
+    withJoinStateManager(inputValueAttributes, joinKeyExpressions, stateFormatVersion) { manager =>
       implicit val mgr = manager
 
       val ex = intercept[Exception] {
@@ -214,7 +320,7 @@ class SymmetricHashJoinStateManagerSuite extends StreamTest with BeforeAndAfter
     // Test with skipNullsForStreamStreamJoins set to true which would skip nulls
     // and continue iterating as part of removeByValue as well as get
     val metric = new SQLMetric("sum")
-    withJoinStateManager(inputValueAttribs, joinKeyExprs, stateFormatVersion, true,
+    withJoinStateManager(inputValueAttributes, joinKeyExpressions, stateFormatVersion, true,
         Some(metric)) { manager =>
       implicit val mgr = manager
 
@@ -245,200 +351,299 @@ class SymmetricHashJoinStateManagerSuite extends StreamTest with BeforeAndAfter
     }
   }
 
-  val watermarkMetadata = new MetadataBuilder().putLong(EventTimeWatermark.delayKey, 10).build()
-  val inputValueSchema = new StructType()
+  protected def updateNumValues(key: Int, numValues: Long)
+                               (implicit manager: SymmetricHashJoinStateManager): Unit = {
+    assert(manager.isInstanceOf[SupportsIndexedKeys])
+    manager.asInstanceOf[SupportsIndexedKeys].updateNumValuesTestOnly(toJoinKeyRow(key), numValues)
+  }
+}
+
+class SymmetricHashJoinStateManagerEventTimeInKeySuite
+  extends SymmetricHashJoinStateManagerBaseSuite {
+
+  private val versionsInTest = SymmetricHashJoinStateManager.supportedVersions
+
+  private val watermarkMetadata = new MetadataBuilder()
+    .putLong(EventTimeWatermark.delayKey, 10).build()
+  private val inputValueSchema = new StructType()
     .add(StructField("time", IntegerType, metadata = watermarkMetadata))
-    .add(StructField("value", BooleanType))
-  val inputValueAttribs = toAttributes(inputValueSchema)
-  val inputValueAttribWithWatermark = inputValueAttribs(0)
-  val joinKeyExprs = Seq[Expression](Literal(false), inputValueAttribWithWatermark, Literal(10.0))
+    .add(StructField("value", IntegerType))
 
-  val inputValueGen = UnsafeProjection.create(inputValueAttribs.map(_.dataType).toArray)
-  val joinKeyGen = UnsafeProjection.create(joinKeyExprs.map(_.dataType).toArray)
+  override protected val inputValueAttributes: Seq[AttributeReference] =
+    toAttributes(inputValueSchema)
+  override protected val inputValueAttributesWithWatermark: AttributeReference =
+    inputValueAttributes(0)
+  override protected val joinKeyExpressions: Seq[Expression] = Seq[Expression](
+    Literal(false),
+    inputValueAttributesWithWatermark,
+    Literal(10.0))
 
-
-  def toInputValue(i: Int): UnsafeRow = {
-    inputValueGen.apply(new GenericInternalRow(Array[Any](i, false)))
-  }
-
-  def toJoinKeyRow(i: Int): UnsafeRow = {
-    joinKeyGen.apply(new GenericInternalRow(Array[Any](false, i, 10.0)))
-  }
-
-  def toValueInt(inputValueRow: UnsafeRow): Int = inputValueRow.getInt(0)
-
-  def append(key: Int, value: Int)(implicit manager: SymmetricHashJoinStateManager): Unit = {
-    // we only put matched = false for simplicity - StreamingJoinSuite will test the functionality
-    manager.append(toJoinKeyRow(key), toInputValue(value), matched = false)
-  }
-
-  def appendAndTest(key: Int, values: Int*)
-                   (implicit manager: SymmetricHashJoinStateManager): Unit = {
-    values.foreach { value => append(key, value)}
-    require(get(key) === values)
-  }
-
-  def updateNumValues(key: Int, numValues: Long)
-                     (implicit manager: SymmetricHashJoinStateManager): Unit = {
-    manager.updateNumValuesTestOnly(toJoinKeyRow(key), numValues)
-  }
-
-  def getNumValues(key: Int)
-                  (implicit manager: SymmetricHashJoinStateManager): Int = {
-    manager.get(toJoinKeyRow(key)).size
-  }
-
-  def get(key: Int)(implicit manager: SymmetricHashJoinStateManager): Seq[Int] = {
-    manager.get(toJoinKeyRow(key)).map(toValueInt).toSeq.sorted
-  }
-
-  /** Remove keys (and corresponding values) where `time <= threshold` */
-  def removeByKey(threshold: Long)(implicit manager: SymmetricHashJoinStateManager): Unit = {
-    val expr =
-      LessThanOrEqual(
-        BoundReference(
-          1, inputValueAttribWithWatermark.dataType, inputValueAttribWithWatermark.nullable),
-        Literal(threshold))
-    val iter = manager.removeByKeyCondition(GeneratePredicate.generate(expr).eval _)
-    while (iter.hasNext) iter.next()
-  }
-
-  /** Remove values where `time <= threshold` */
-  def removeByValue(watermark: Long)(implicit manager: SymmetricHashJoinStateManager): Unit = {
-    val expr = LessThanOrEqual(inputValueAttribWithWatermark, Literal(watermark))
-    val iter = manager.removeByValueCondition(
-      GeneratePredicate.generate(expr, inputValueAttribs).eval _)
-    while (iter.hasNext) iter.next()
-  }
-
-  def assertNumRows(stateFormatVersion: Int, target: Long)(
-    implicit manager: SymmetricHashJoinStateManager): Unit = {
-    // This suite originally uses HDFSBackStateStoreProvider, which provides instantaneous metrics
-    // for numRows.
-    // But for version 3 with virtual column families, RocksDBStateStoreProvider updates metrics
-    // asynchronously. This means the number of keys obtained from the metrics are very likely
-    // to be outdated right after a put/remove.
-    if (stateFormatVersion <= 2) {
-      assert(manager.metrics.numKeys == target)
+  versionsInTest.foreach { ver =>
+    test(s"StreamingJoinStateManager V$ver - all operations") {
+      testAllOperations(ver)
     }
   }
 
-  def withJoinStateManager(
-      inputValueAttribs: Seq[Attribute],
-      joinKeyExprs: Seq[Expression],
-      stateFormatVersion: Int,
-      skipNullsForStreamStreamJoins: Boolean = false,
-      metric: Option[SQLMetric] = None)
-      (f: SymmetricHashJoinStateManager => Unit): Unit = {
-    // HDFS store providers do not support virtual column families
-    val storeProvider = if (stateFormatVersion == 3) {
-      classOf[RocksDBStateStoreProvider].getName
-    } else {
-      classOf[HDFSBackedStateStoreProvider].getName
+  versionsInTest.foreach { ver =>
+    test(s"StreamingJoinStateManager V$ver - all operations, with commit and load in between") {
+      testAllOperationsWithCommitAndLoad(ver, changelogCheckpoint = false)
+      testAllOperationsWithCommitAndLoad(ver, changelogCheckpoint = true)
     }
-    withTempDir { file =>
-      withSQLConf(
-        SQLConf.STATE_STORE_SKIP_NULLS_FOR_STREAM_STREAM_JOINS.key ->
-          skipNullsForStreamStreamJoins.toString,
-        SQLConf.STATE_STORE_PROVIDER_CLASS.key -> storeProvider
-      ) {
-        val storeConf = new StateStoreConf(spark.sessionState.conf)
-        val stateInfo = StatefulOperatorStateInfo(
-          file.getAbsolutePath, UUID.randomUUID, 0, 0, 5, None)
-        val manager = SymmetricHashJoinStateManager(
-          LeftSide, inputValueAttribs, joinKeyExprs, Some(stateInfo), storeConf, new Configuration,
-          partitionId = 0, None, None, stateFormatVersion, metric,
-          joinStoreGenerator = new JoinStateManagerStoreGenerator())
-        try {
-          f(manager)
-        } finally {
-          manager.abortIfNeeded()
-        }
-      }
-    }
-    StateStore.stop()
   }
 
-  private def testPartitionKeyExtraction(stateFormatVersion: Int): Unit = {
-    withJoinStateManager(inputValueAttribs, joinKeyExprs, stateFormatVersion) { manager =>
+  private def testAllOperations(stateFormatVersion: Int): Unit = {
+    withJoinStateManager(
+      inputValueAttributes,
+      joinKeyExpressions,
+      stateFormatVersion = stateFormatVersion) { manager =>
       implicit val mgr = manager
 
-      val joinKeySchema = StructType(
-        joinKeyExprs.zipWithIndex.map { case (expr, i) =>
-          StructField(s"field$i", expr.dataType, expr.nullable)
-        })
+      assert(get(20) === Seq.empty)     // initially empty
+      append(20, 2)
+      assert(get(20) === Seq(2))        // should first value correctly
+      assertNumRows(stateFormatVersion, 1)
 
-      // Add some test data
-      append(key = 20, value = 100)
-      append(key = 20, value = 200)
-      append(key = 30, value = 150)
+      append(20, 3)
+      assert(get(20) === Seq(2, 3))     // should append new values
+      append(20, 3)
+      assert(get(20) === Seq(2, 3, 3))  // should append another copy if same value added again
+      assertNumRows(stateFormatVersion, 3)
 
-      Seq(
-        (getKeyToNumValuesStoreAndKeySchema(), SymmetricHashJoinStateManager
-          .getStateStoreName(LeftSide, SymmetricHashJoinStateManager.KeyToNumValuesType),
-          // expect 1 for both key 20 & 30
-          1, 1),
-        (getKeyWithIndexToValueStoreAndKeySchema(), SymmetricHashJoinStateManager
-          .getStateStoreName(LeftSide, SymmetricHashJoinStateManager.KeyWithIndexToValueType),
-          // expect 2 for key 20 & 1 for key 30
-          2, 1)
-      ).foreach { case ((store, keySchema), name, expectedNumKey20, expectedNumKey30) =>
-        val storeName = if (stateFormatVersion == 3) {
-          StateStoreId.DEFAULT_STORE_NAME
-        } else {
-          name
-        }
+      assert(get(30) === Seq.empty)
+      append(30, 1)
+      assert(get(30) === Seq(1))
+      assert(get(20) === Seq(2, 3, 3))  // add another key-value should not affect existing ones
+      assertNumRows(stateFormatVersion, 4)
 
-        val colFamilyName = if (stateFormatVersion == 3) {
-          name
-        } else {
-          StateStore.DEFAULT_COL_FAMILY_NAME
-        }
+      removeByKey(25)
+      assert(get(20) === Seq.empty)
+      assert(get(30) === Seq(1))        // should remove 20, not 30
+      assertNumRows(stateFormatVersion, 1)
 
-        val extractor = StatePartitionKeyExtractorFactory.create(
-          StatefulOperatorsUtils.SYMMETRIC_HASH_JOIN_EXEC_OP_NAME,
-          keySchema,
-          storeName,
-          colFamilyName,
-          stateFormatVersion = Some(stateFormatVersion)
-        )
-
-        assert(extractor.partitionKeySchema === joinKeySchema,
-          "Partition key schema should match the join key schema")
-
-        // Copy both the state key and partition key to avoid UnsafeRow reuse issues
-        val stateKeys = store.iterator(colFamilyName).map(_.key.copy()).toList
-        val partitionKeys = stateKeys.map(extractor.partitionKey(_).copy())
-
-        assert(partitionKeys.length === expectedNumKey20 + expectedNumKey30,
-          "Should have same num partition keys as num state store keys")
-        assert(partitionKeys.count(_ === toJoinKeyRow(20)) === expectedNumKey20,
-          "Should have the expected num partition keys for join key 20")
-        assert(partitionKeys.count(_ === toJoinKeyRow(30)) === expectedNumKey30,
-          "Should have the expected num partition keys for join key 30")
-      }
+      removeByKey(30)
+      assert(get(30) === Seq.empty)     // should remove 30
+      assertNumRows(stateFormatVersion, 0)
     }
   }
 
-  def getKeyToNumValuesStoreAndKeySchema()
-      (implicit manager: SymmetricHashJoinStateManager): (StateStore, StructType) = {
-    val keyToNumValuesHandler = manager.keyToNumValues
-    val keyToNumValuesStoreMethod = PrivateMethod[StateStore](Symbol("stateStore"))
-    val keyToNumValuesStore = keyToNumValuesHandler.invokePrivate(keyToNumValuesStoreMethod())
+  private def testAllOperationsWithCommitAndLoad(
+      stateFormatVersion: Int,
+      changelogCheckpoint: Boolean): Unit = {
+    withTempDir { checkpointDir =>
+      withJoinStateManagerWithCheckpointDir(
+        inputValueAttributes,
+        joinKeyExpressions,
+        stateFormatVersion = stateFormatVersion,
+        checkpointDir,
+        storeVersion = 0,
+        changelogCheckpoint = changelogCheckpoint) { manager =>
 
-    (keyToNumValuesStore, manager.keySchema)
+        implicit val mgr = manager
+
+        assert(get(20) === Seq.empty)     // initially empty
+        append(20, 2)
+        assert(get(20) === Seq(2))        // should first value correctly
+
+        append(20, 3)
+        assert(get(20) === Seq(2, 3))     // should append new values
+        append(20, 3)
+        assert(get(20) === Seq(2, 3, 3))  // should append another copy if same value added again
+
+        mgr.commit()
+      }
+
+      withJoinStateManagerWithCheckpointDir(
+        inputValueAttributes,
+        joinKeyExpressions,
+        stateFormatVersion = stateFormatVersion,
+        checkpointDir,
+        storeVersion = 1,
+        changelogCheckpoint = changelogCheckpoint) { manager =>
+
+        implicit val mgr = manager
+
+        assert(get(30) === Seq.empty)
+        append(30, 1)
+        assert(get(30) === Seq(1))
+        assert(get(20) === Seq(2, 3, 3))  // add another key-value should not affect existing ones
+
+        removeByKey(25)
+        assert(get(20) === Seq.empty)
+        assert(get(30) === Seq(1))        // should remove 20, not 30
+
+        mgr.commit()
+      }
+
+      withJoinStateManagerWithCheckpointDir(
+        inputValueAttributes,
+        joinKeyExpressions,
+        stateFormatVersion = stateFormatVersion,
+        checkpointDir,
+        storeVersion = 2,
+        changelogCheckpoint = changelogCheckpoint) { manager =>
+
+        implicit val mgr = manager
+
+        removeByKey(30)
+        assert(get(30) === Seq.empty)     // should remove 30
+
+        mgr.commit()
+      }
+    }
+  }
+}
+
+class SymmetricHashJoinStateManagerEventTimeInValueSuite
+  extends SymmetricHashJoinStateManagerBaseSuite {
+
+  private val versionsInTest = SymmetricHashJoinStateManager.supportedVersions
+
+  private val watermarkMetadata = new MetadataBuilder()
+    .putLong(EventTimeWatermark.delayKey, 10).build()
+  private val inputValueSchema = new StructType()
+    .add(StructField("key", IntegerType))
+    .add(StructField("time", IntegerType, metadata = watermarkMetadata))
+
+  protected override val inputValueAttributes = toAttributes(inputValueSchema)
+  protected override val inputValueAttributesWithWatermark = inputValueAttributes(1)
+  protected override val joinKeyExpressions = Seq[Expression](
+    Literal(false), inputValueAttributes(0), Literal(10.0))
+
+  versionsInTest.foreach { ver =>
+    test(s"StreamingJoinStateManager V$ver - all operations") {
+      testAllOperations(ver)
+    }
   }
 
-  def getKeyWithIndexToValueStoreAndKeySchema()
-      (implicit manager: SymmetricHashJoinStateManager): (StateStore, StructType) = {
-    val keyWithIndexToValueHandler = manager.keyWithIndexToValue
+  versionsInTest.foreach { ver =>
+    test(s"StreamingJoinStateManager V$ver - all operations, with commit and load in between") {
+      testAllOperationsWithCommitAndLoad(ver, changelogCheckpoint = false)
+      testAllOperationsWithCommitAndLoad(ver, changelogCheckpoint = true)
+    }
+  }
 
-    val keyWithIndexToValueStoreMethod = PrivateMethod[StateStore](Symbol("stateStore"))
-    val keyWithIndexToValueStore =
-      keyWithIndexToValueHandler.invokePrivate(keyWithIndexToValueStoreMethod())
+  private def testAllOperations(stateFormatVersion: Int): Unit = {
+    withJoinStateManager(
+      inputValueAttributes,
+      joinKeyExpressions,
+      stateFormatVersion = stateFormatVersion) { manager =>
+      implicit val mgr = manager
 
-    val keySchemaMethod = PrivateMethod[StructType](Symbol("keyWithIndexSchema"))
-    val keyWithIndexToValueKeySchema = keyWithIndexToValueHandler.invokePrivate(keySchemaMethod())
-    (keyWithIndexToValueStore, keyWithIndexToValueKeySchema)
+      appendAndTest(40, 100, 200, 300)
+      appendAndTest(50, 125)
+      appendAndTest(60, 275)              // prepare for testing removeByValue
+      assertNumRows(stateFormatVersion, 5)
+
+      removeByValue(125)
+      assert(get(40) === Seq(200, 300))
+      assert(get(50) === Seq.empty)
+      assert(get(60) === Seq(275))        // should remove only some values, not all
+      assertNumRows(stateFormatVersion, 3)
+
+      append(40, 50)
+      assert(get(40) === Seq(50, 200, 300))
+      assertNumRows(stateFormatVersion, 4)
+
+      removeByValue(200)
+      assert(get(40) === Seq(300))
+      assert(get(60) === Seq(275))        // should remove only some values, not all
+      assertNumRows(stateFormatVersion, 2)
+
+      removeByValue(300)
+      assert(get(40) === Seq.empty)
+      assert(get(60) === Seq.empty)       // should remove all values now
+      assertNumRows(stateFormatVersion, 0)
+    }
+  }
+
+  private def testAllOperationsWithCommitAndLoad(
+      stateFormatVersion: Int,
+      changelogCheckpoint: Boolean): Unit = {
+    withTempDir { checkpointDir =>
+      withJoinStateManagerWithCheckpointDir(
+        inputValueAttributes,
+        joinKeyExpressions,
+        stateFormatVersion = stateFormatVersion,
+        checkpointDir,
+        storeVersion = 0,
+        changelogCheckpoint = changelogCheckpoint) { manager =>
+
+        implicit val mgr = manager
+
+        appendAndTest(40, 100, 200, 300)
+        appendAndTest(50, 125)
+        appendAndTest(60, 275) // prepare for testing removeByValue
+
+        mgr.commit()
+      }
+
+      withJoinStateManagerWithCheckpointDir(
+        inputValueAttributes,
+        joinKeyExpressions,
+        stateFormatVersion = stateFormatVersion,
+        checkpointDir,
+        storeVersion = 1,
+        changelogCheckpoint = changelogCheckpoint) { manager =>
+
+        implicit val mgr = manager
+
+        removeByValue(125)
+        assert(get(40) === Seq(200, 300))
+        assert(get(50) === Seq.empty)
+        assert(get(60) === Seq(275))        // should remove only some values, not all
+
+        mgr.commit()
+      }
+
+      withJoinStateManagerWithCheckpointDir(
+        inputValueAttributes,
+        joinKeyExpressions,
+        stateFormatVersion = stateFormatVersion,
+        checkpointDir,
+        storeVersion = 2,
+        changelogCheckpoint = changelogCheckpoint) { manager =>
+
+        implicit val mgr = manager
+
+        append(40, 50)
+        assert(get(40) === Seq(50, 200, 300))
+
+        mgr.commit()
+      }
+
+      withJoinStateManagerWithCheckpointDir(
+        inputValueAttributes,
+        joinKeyExpressions,
+        stateFormatVersion = stateFormatVersion,
+        checkpointDir,
+        storeVersion = 3,
+        changelogCheckpoint = changelogCheckpoint) { manager =>
+
+        implicit val mgr = manager
+
+        removeByValue(200)
+        assert(get(40) === Seq(300))
+        assert(get(60) === Seq(275))        // should remove only some values, not all
+
+        mgr.commit()
+      }
+
+      withJoinStateManagerWithCheckpointDir(
+        inputValueAttributes,
+        joinKeyExpressions,
+        stateFormatVersion = stateFormatVersion,
+        checkpointDir,
+        storeVersion = 4,
+        changelogCheckpoint = changelogCheckpoint) { manager =>
+
+        implicit val mgr = manager
+
+        removeByValue(300)
+        assert(get(40) === Seq.empty)
+        assert(get(60) === Seq.empty)       // should remove all values now
+
+        mgr.commit()
+      }
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to implement the new state format for stream-stream join, based on the new state key encoding w.r.t. event time awareness.

The new state format is focused to eliminate the necessity of full scan during eviction & populating unmatched rows. The overhead of eviction should have bound to the actual number of state rows to be evicted (indirectly impacted by the amount of watermark advancement), but we have been doing the full scan with the existing state format, which could take more than 2 seconds in 1,000,000 rows even if there is zero row to be evicted. The overhead of eviction with the new state format would be bound to the actual number of state rows to be evicted, taking around 30ms or even less in 1,000,000 rows when there is zero row to be evicted.

To achieve the above, we make a drastic change of data structure to move out from the logical array, and introduce a secondary index in addition to the main data.

Each side of the join will use two (virtual) column families (total 4 column families), which are following:

* KeyWithTsToValuesStore
  * Primary data store
  * (key, event time) -> values
  * each element in values consists of (value, matched)
* TsWithKeyTypeStore
  * Secondary index for efficient eviction
  * (event time, key) -> numValues
  * numValues is kept updated when a new value is added into values in primary data store
    * This is to track the number of deleted rows accurately. It's optional but the metric has been useful so we want to keep it as it is.

As the format of key part implies, KeyWithTsToValuesStore will use `EventTimeAsPostfixStateEncoderSpec`, and TsWithKeyTypeStore will use `EventTimeAsPrefixStateEncoderSpec`.

The granularity of the timestamp for event time is 1 millisecond, which is in line with the granularity for watermark advancement. This can be a kind of knob controlling the number of the keys vs the number of the values in the key, trading off the granularity of eviction based on watermark advancement vs the size of key space (may impact performance).

Note that the amount of bytes to write will be "increased" compared to the existing state format. If assuming 10 rows having 10 timestamps are bound to a single key, 

* existing state format: key bytes would appear 11 times (1 time in KeyToNumValuesStore, 10 times in KeyWithIndexToValueStore)
* new state format: key bytes would appear 20 times (10 times in KeyWithTsToValuesStore, 10 times in TsWithKeyTypeStore)

This could incur performance regression of insertion, but retrieval and eviction have improved with the new state format, which covers the regression and can show much better performance in terms of the scenario of shorter batch duration & huge state store size.

There are several follow-ups with this state format implementation, which can be addressed on top of this:

* yet to cover the case of regular join where there is no event time in both join condition and the value
  * addressing this is needed to unify the state format and minimize the cost of maintenance 
  * 1 millisecond timestamp granularity does not work with the performance
  * we need to find a way to avoid regression on insertion since that join case doesn't have eviction, which don't have a strong benefit of this format
* further optimizations with RocksDB offering: WriteBatch (for batched writes), MGET, etc.
* retrieving matched rows with the "scope" of timestamps (in time-interval join)
  * while the format is ready to support ordered scan of timestamp, this needs another state store API to define the range of keys to scan, which needs some effort

### Why are the changes needed?

The cost of eviction based on full scan is severe to make the stream-stream join to be lower latency. Also, the logic of maintaining logical array is complicated enough to maintain and the performance characteristic is less predictable given the behavior of deleting the element in random index (placing the value of the last index to the deleted index).

### Does this PR introduce _any_ user-facing change?

No. At this point, this state format is not integrated with the actual stream-stream join operator, and we need to do follow-up work for integration to finally introduce the change to user-facing.

### How was this patch tested?

New UT suites, refactoring the existing suite to test with both time window and time interval cases.

### Was this patch authored or co-authored using generative AI tooling?

No.