### PR TITLE
[WIP][BEFORE-SUBMISSION] Set upper bound for RocksDB Iterator

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -1589,18 +1589,28 @@ class RocksDB(
       prefix: Array[Byte],
       cfName: String = StateStore.DEFAULT_COL_FAMILY_NAME): NextIterator[ByteArrayPair] = {
     updateMemoryUsageIfNeeded()
-    val iter = db.newIterator()
     val updatedPrefix = if (useColumnFamilies) {
       encodeStateRowWithPrefix(prefix, cfName)
     } else {
       prefix
     }
 
+    val upperBoundSlice = RocksDB.prefixUpperBound(updatedPrefix).map(new Slice(_))
+    val prefixScanReadOptions = new ReadOptions()
+    upperBoundSlice.foreach(prefixScanReadOptions.setIterateUpperBound)
+
+    val iter = db.newIterator(prefixScanReadOptions)
     iter.seek(updatedPrefix)
+
+    private def closeResources(): Unit = {
+      iter.close()
+      prefixScanReadOptions.close()
+      upperBoundSlice.foreach(_.close())
+    }
 
     // Attempt to close this iterator if there is a task failure, or a task interruption.
     Option(TaskContext.get()).foreach { tc =>
-      tc.addTaskCompletionListener[Unit] { _ => iter.close() }
+      tc.addTaskCompletionListener[Unit] { _ => closeResources() }
     }
 
     new NextIterator[ByteArrayPair] {
@@ -1624,12 +1634,12 @@ class RocksDB(
           byteArrayPair
         } else {
           finished = true
-          iter.close()
+          closeResources()
           null
         }
       }
 
-      override protected def close(): Unit = { iter.close() }
+      override protected def close(): Unit = closeResources()
     }
   }
 
@@ -2225,6 +2235,27 @@ class RocksDB(
 }
 
 object RocksDB extends Logging {
+
+  /**
+   * Computes the exclusive upper bound for a prefix byte array by incrementing the prefix.
+   * For example, [0x01, 0x02, 0x03] -> Some([0x01, 0x02, 0x04]).
+   * Returns None if the prefix is all 0xFF bytes (no finite upper bound exists).
+   */
+  def prefixUpperBound(prefix: Array[Byte]): Option[Array[Byte]] = {
+    if (prefix.isEmpty) return None
+
+    var i = prefix.length - 1
+    while (i >= 0) {
+      val incremented = (prefix(i) & 0xFF) + 1
+      if (incremented <= 0xFF) {
+        val upperBound = java.util.Arrays.copyOf(prefix, i + 1)
+        upperBound(i) = incremented.toByte
+        return Some(upperBound)
+      }
+      i -= 1
+    }
+    None
+  }
 
   val mainMemorySources: Seq[String] = Seq(
     "rocksdb.estimate-table-readers-mem",

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -4493,6 +4493,82 @@ class RocksDBSuite extends AlsoTestWithRocksDBFeatures with SharedSparkSession
     assert(provider.rocksDB.localRootDir.getParent() == System.getProperty("java.io.tmpdir"))
   }
 
+  test("prefixUpperBound computes correct exclusive upper bound") {
+    def assertBound(input: Array[Byte], expected: Option[Seq[Byte]]): Unit = {
+      assert(RocksDB.prefixUpperBound(input).map(_.toSeq) === expected)
+    }
+
+    // Normal increment
+    assertBound(Array(0x01, 0x02, 0x03), Some(Seq(0x01, 0x02, 0x04)))
+
+    // Single byte
+    assertBound(Array(0x05), Some(Seq(0x06)))
+
+    // Carry: last byte is 0xFF, so it's dropped and previous byte is incremented
+    assertBound(Array(0x01, 0xFF.toByte), Some(Seq(0x02)))
+
+    // Carry: trailing bytes after the incremented position are removed
+    assertBound(Array(0x01, 0x02, 0xFF.toByte), Some(Seq(0x01, 0x03)))
+
+    // Multiple carry
+    assertBound(Array(0x01, 0xFF.toByte, 0xFF.toByte), Some(Seq(0x02)))
+
+    // All 0xFF: no finite upper bound
+    assertBound(Array(0xFF.toByte, 0xFF.toByte), None)
+
+    // Single 0xFF
+    assertBound(Array(0xFF.toByte), None)
+
+    // Empty prefix
+    assertBound(Array.empty[Byte], None)
+
+    // Zero byte
+    assertBound(Array(0x00.toByte), Some(Seq(0x01)))
+  }
+
+  testWithColumnFamilies(
+    "prefixScan returns only keys matching the prefix",
+    TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
+    val remoteDir = Utils.createTempDir().getAbsolutePath
+
+    withDB(remoteDir, useColumnFamilies = colFamiliesEnabled) { db =>
+      val cfName = if (colFamiliesEnabled) {
+        val cf = "testCF"
+        db.createColFamilyIfAbsent(cf, isInternal = false)
+        cf
+      } else {
+        StateStore.DEFAULT_COL_FAMILY_NAME
+      }
+
+      db.put("aa1", "v1", cfName)
+      db.put("aa2", "v2", cfName)
+      db.put("ab1", "v3", cfName)
+      db.put("bb1", "v4", cfName)
+      db.commit()
+
+      db.load(1)
+
+      val resultAA = db.prefixScan("aa".getBytes, cfName).map(toStr).toSeq
+      assert(resultAA.map(_._1).toSet === Set("aa1", "aa2"))
+      assert(resultAA.size === 2)
+
+      val resultAB = db.prefixScan("ab".getBytes, cfName).map(toStr).toSeq
+      assert(resultAB.map(_._1).toSet === Set("ab1"))
+      assert(resultAB.size === 1)
+
+      val resultBB = db.prefixScan("bb".getBytes, cfName).map(toStr).toSeq
+      assert(resultBB.map(_._1).toSet === Set("bb1"))
+      assert(resultBB.size === 1)
+
+      val resultCC = db.prefixScan("cc".getBytes, cfName).map(toStr).toSeq
+      assert(resultCC.isEmpty)
+
+      val resultA = db.prefixScan("a".getBytes, cfName).map(toStr).toSeq
+      assert(resultA.map(_._1).toSet === Set("aa1", "aa2", "ab1"))
+      assert(resultA.size === 3)
+    }
+  }
+
   private def dbConf = RocksDBConf(StateStoreConf(SQLConf.get.clone()))
 
   class RocksDBCheckpointFormatV2(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
